### PR TITLE
Add admin stack preview using shared grouping util

### DIFF
--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -117,6 +117,15 @@ function renderTripsTab(panel) {
   galleryEl.style.marginTop = '1rem';
   panel.appendChild(galleryEl);
 
+  const iframe = document.createElement('iframe');
+  iframe.id = 'preview-frame';
+  iframe.style.width = '100%';
+  iframe.style.height = '60vh';
+  iframe.style.marginTop = '1rem';
+  iframe.style.display = 'none';
+  iframe.setAttribute('title', 'Day Preview');
+  panel.appendChild(iframe);
+
   const previewEl = document.createElement('div');
   previewEl.id = 'stack-preview';
   previewEl.className = 'gallery';
@@ -395,7 +404,13 @@ function renderTripsTab(panel) {
   }
 
   function previewDay() {
-    previewEl.style.display = previewEl.style.display === 'none' ? 'grid' : 'none';
+    const show = previewEl.style.display === 'none';
+    previewEl.style.display = show ? 'grid' : 'none';
+    iframe.style.display = show ? 'block' : 'none';
+    if (show && dayData) {
+      iframe.src = `../day.html?date=${encodeURIComponent(dayData.slug)}`;
+      iframe.focus();
+    }
   }
 
   async function publishSelected() {

--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -1,6 +1,8 @@
 /* global L */
 // admin/admin.js
 
+import { groupIntoStacks } from "../js/utils.js";
+
 const PASS_KEY = 'tripAdminPass';
 const SETTINGS_KEY = 'tripAdminSettings';
 const app = document.getElementById('app');
@@ -115,17 +117,16 @@ function renderTripsTab(panel) {
   galleryEl.style.marginTop = '1rem';
   panel.appendChild(galleryEl);
 
-  const iframe = document.createElement('iframe');
-  iframe.id = 'preview-frame';
-  iframe.style.width = '100%';
-  iframe.style.height = '60vh';
-  iframe.style.marginTop = '1rem';
-  iframe.style.display = 'none';
-  iframe.setAttribute('title', 'Day Preview');
-  panel.appendChild(iframe);
+  const previewEl = document.createElement('div');
+  previewEl.id = 'stack-preview';
+  previewEl.className = 'gallery';
+  previewEl.style.marginTop = '1rem';
+  previewEl.style.display = 'none';
+  panel.appendChild(previewEl);
 
   let dayData = null;
   let map = null;
+  let dayStacks = [];
 
   const settings = loadSettings();
   const apiBase = settings.apiBase || '';
@@ -298,9 +299,32 @@ function renderTripsTab(panel) {
           });
           dayData.photos = newOrder;
           // reset idx
-          galleryEl.querySelectorAll('[draggable]').forEach((c, i) => { c.dataset.idx = String(i); });
-        }
-      });
+    galleryEl.querySelectorAll('[draggable]').forEach((c, i) => { c.dataset.idx = String(i); });
+      }
+    });
+  });
+
+    dayStacks = groupIntoStacks(dayData.photos || [], 50);
+    renderPreview();
+  }
+
+  function renderPreview() {
+    previewEl.innerHTML = '';
+    dayStacks.forEach((s) => {
+      const wrap = document.createElement('div');
+      wrap.style.position = 'relative';
+      const img = document.createElement('img');
+      const first = s.photos[0] || {};
+      img.src = first.thumb || first.url;
+      img.alt = s.title || '';
+      wrap.appendChild(img);
+      if (s.photos.length > 1) {
+        const chip = document.createElement('div');
+        chip.className = 'chip';
+        chip.textContent = String(s.photos.length);
+        wrap.appendChild(chip);
+      }
+      previewEl.appendChild(wrap);
     });
   }
 
@@ -371,9 +395,7 @@ function renderTripsTab(panel) {
   }
 
   function previewDay() {
-    iframe.src = `../day.html?date=${encodeURIComponent(dayData.slug)}`;
-    iframe.style.display = 'block';
-    iframe.focus();
+    previewEl.style.display = previewEl.style.display === 'none' ? 'grid' : 'none';
   }
 
   async function publishSelected() {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,4 +1,4 @@
-import { dataUrl, getApiBase, haversineKm, debounce, urlParam, pushUrlParam, replaceUrlParam, fmtTime } from "./utils.js";
+import { dataUrl, getApiBase, groupIntoStacks, debounce, urlParam, pushUrlParam, replaceUrlParam, fmtTime } from "./utils.js";
 
 const isMobile = matchMedia('(max-width:768px)').matches;
 let topMap; // no mini-map when sticky hero map is always visible
@@ -87,39 +87,6 @@ async function init(){
 }
 
 // ---------- data ----------
-function groupIntoStacks(photos, radiusMeters) {
-  const stacks = [];
-  const used = new Set();
-  const radiusKm = radiusMeters / 1000; // convert meters to kilometers
-  let idx = 0;
-
-  for (let i = 0; i < photos.length; i++) {
-    if (used.has(i)) continue;
-    const a = photos[i];
-    const group = [a];
-    used.add(i);
-
-    for (let j = i + 1; j < photos.length; j++) {
-      if (used.has(j)) continue;
-      const b = photos[j];
-      if (haversineKm(a.lat, a.lon, b.lat, b.lon) <= radiusKm) {
-        group.push(b);
-        used.add(j);
-      }
-    }
-
-    stacks.push({
-      id: `stack-${idx++}`,
-      title: a.caption || a.dayTitle,
-      location: { lat: a.lat, lng: a.lon, label: `${a.lat.toFixed(4)}, ${a.lon.toFixed(4)}` },
-      photos: group,
-      takenAt: a.taken_at
-    });
-  }
-
-  return stacks;
-}
-
 // Drag-to-scroll helper function
 function makeDragScrollable(el) {
   let isDown = false, startX = 0, startScroll = 0;

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -33,6 +33,40 @@ export function haversineKm(lat1, lon1, lat2, lon2) {
   return 2 * R * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
 }
 
+// --- stacking ---
+export function groupIntoStacks(photos, radiusMeters) {
+  const stacks = [];
+  const used = new Set();
+  const radiusKm = radiusMeters / 1000; // convert meters to kilometers
+  let idx = 0;
+
+  for (let i = 0; i < photos.length; i++) {
+    if (used.has(i)) continue;
+    const a = photos[i];
+    const group = [a];
+    used.add(i);
+
+    for (let j = i + 1; j < photos.length; j++) {
+      if (used.has(j)) continue;
+      const b = photos[j];
+      if (haversineKm(a.lat, a.lon, b.lat, b.lon) <= radiusKm) {
+        group.push(b);
+        used.add(j);
+      }
+    }
+
+    stacks.push({
+      id: `stack-${idx++}`,
+      title: a.caption || a.dayTitle,
+      location: { lat: a.lat, lng: a.lon, label: `${a.lat.toFixed(4)}, ${a.lon.toFixed(4)}` },
+      photos: group,
+      takenAt: a.taken_at
+    });
+  }
+
+  return stacks;
+}
+
 // --- misc ---
 export const debounce = (fn, ms=120) => { let t; return (...a)=>{ clearTimeout(t); t=setTimeout(()=>fn(...a), ms); }; };
 export const fmtTime = (iso) => new Date(iso).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', hour12:false});


### PR DESCRIPTION
## Summary
- Share photo stacking logic via new `groupIntoStacks` utility
- Use stacking utility in index feed and admin
- Add admin preview of stacks with cover image and count toggle

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5ba5de53483238e02a03f74731570