### PR TITLE
Handle incremental photo imports without duplication

### DIFF
--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -171,7 +171,7 @@ function renderTripsTab(panel) {
       title: `Day — ${dateVal}`, stats:{}, polyline:{type:'LineString', coordinates:[]}, points:[], photos:[]
     };
 
-    // Ask our backend to fetch photos for that calendar day (TEMPORARY: using local test route)
+    // Ask backend to import any new photos for that calendar day
     const url = `${s.apiBase}/api/local/day?date=${dateVal}`;
     const resp = await fetch(url);
     if (!resp.ok) {
@@ -179,14 +179,25 @@ function renderTripsTab(panel) {
       console.warn('Local import failed', err);
       return alert('Local import failed. Check the server logs.');
     }
+
     const data = await resp.json();
-    dayData.photos = data.photos || [];
+    const incoming = data.photos || [];
+    const seen = new Set((dayData.photos || []).map((p) => p.id || p.url));
+    let added = 0;
+    incoming.forEach((p) => {
+      const key = p.id || p.url;
+      if (!seen.has(key)) {
+        dayData.photos.push(p);
+        seen.add(key);
+        added += 1;
+      }
+    });
 
     renderDay();
     controls.querySelector('#save-day').disabled = false;
     controls.querySelector('#preview-day').disabled = false;
     controls.querySelector('#publish-day').disabled = false;
-    alert(`Imported ${dayData.photos.length} photos from Immich for ${dateVal}`);
+    alert(`Imported ${added} new photos from Immich for ${dateVal}`);
   }
 
   function renderDay() {


### PR DESCRIPTION
## Summary
- Append imported photos for the selected day instead of replacing existing list
- Avoid duplicate photo entries and alert how many new assets were imported

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5b8f124bc8323bbcd8181b714055c