### PR TITLE
Increase photo stack radius to 500m

### DIFF
--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -658,12 +658,12 @@ function renderTripsTab(panel) {
     });
   });
 
-    dayStacks = groupIntoStacks(dayData.photos || [], 50);
+    dayStacks = groupIntoStacks(dayData.photos || [], 500);
   }
 
   function renderStacks() {
     stackEl.innerHTML = '';
-    const stacks = groupIntoStacks(dayData.photos || [], 50);
+    const stacks = groupIntoStacks(dayData.photos || [], 500);
     stacks.forEach((st) => {
       const div = document.createElement('div');
       div.className = 'stack-item';

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -121,8 +121,8 @@ async function loadStacks(){
   }));
   all.sort((a,b)=>a.ts-b.ts);
 
-  // group photos into stacks by proximity
-  photoStacks = groupIntoStacks(all, 50);
+  // group photos into stacks by proximity (500m radius)
+  photoStacks = groupIntoStacks(all, 500);
 }
 
 // ---------- maps ----------


### PR DESCRIPTION
## Summary
- Group photos by 500m radius on public trip map
- Stack day photos within 500m in admin interface

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a62a049ae08323bf8bfe67d8f6c693