### PR TITLE
Limit homepage map zoom for global view

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -160,7 +160,7 @@ function initMaps(){
       b.extend([p.lat, p.lon]);
     }
   });
-  topMap.fitBounds(b, { padding:[20,20] });
+  topMap.fitBounds(b, { padding:[20,20], maxZoom:3 });
 
   // Important when sticky containers change size / orientation
   setTimeout(()=>topMap.invalidateSize(), 250);


### PR DESCRIPTION
## Summary
- prevent the homepage map from zooming in too closely by capping fitBounds to zoom level 3, ensuring a global default view

## Testing
- `npm test` *(fails: Missing script "test" — no tests provided)*

------
https://chatgpt.com/codex/tasks/task_e_68a70add543083238ca830474fa5ba6a