### PR TITLE
Avoid zooming lightbox images

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -314,7 +314,18 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 .lb-portal.on { display:block; }
 .lb-backdrop { position:absolute; inset:0; background:rgba(0,0,0,.85); }
 .lb-frame { position:absolute; inset:4% 6%; background:rgba(10,10,10,.85); border-radius:12px; border:1px solid rgba(255,255,255,.08); display:grid; grid-template-columns: 1fr minmax(280px, 340px); gap:0; overflow:hidden; }
-.lb-img { width:100%; height:100%; object-fit:contain; grid-column:1/2; grid-row:1/2; background:#000; }
+.lb-img {
+  max-width:100%;
+  max-height:100%;
+  width:auto;
+  height:auto;
+  object-fit:contain;
+  grid-column:1/2;
+  grid-row:1/2;
+  background:#000;
+  align-self:center;
+  justify-self:center;
+}
 .lb-close { position:absolute; top:10px; right:10px; background:rgba(0,0,0,.6); color:#fff; border:0; border-radius:50%; width:40px; height:40px; cursor:pointer; }
 .lb-nav { position:absolute; top:50%; transform:translateY(-50%); background:rgba(0,0,0,.5); color:#fff; border:0; border-radius:50%; width:48px; height:48px; cursor:pointer; }
 .lb-prev{ left:12px; } .lb-next{ right:12px; }


### PR DESCRIPTION
## Summary
- Prevent lightbox images from scaling beyond their natural size by using max dimensions and centering

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a70a5e31148323ad3c31368421c3f8