### PR TITLE
feat: show bell for stacks with new photos

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -77,11 +77,14 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 .stack-card.active{border-color:var(--accent);box-shadow:0 0 0 3px rgba(37,99,235,.1),var(--shadow-2)}
 
 /* ===== CARD HEADER ===== */
-.stack-card-header, .card-head{display:grid;row-gap:4px;padding:12px 14px;border-bottom:1px solid var(--border)}
+.stack-card-header, .card-head{position:relative;display:grid;row-gap:4px;padding:12px 14px;border-bottom:1px solid var(--border)}
 .stack-card-title, .card-title{font-weight:800;font-size:1.05rem;line-height:1.35;margin:0;color:var(--text)}
 .stack-location-time, .card-sub{color:var(--muted);font-size:.9rem;display:flex;flex-wrap:wrap;gap:.6rem;align-items:center}
 .card-sub .dot::before{content:"•";margin:0 .45rem;color:#cbd5e1}
 .stack-pill{margin-left:auto;background:#eff6ff;border:1px solid #dbeafe;color:#1d4ed8;border-radius:999px;padding:2px 10px;font-weight:700;font-size:.78rem}
+
+/* New photo indicator */
+.new-photo-bell{position:absolute;top:12px;right:14px;font-size:1.1rem;color:#f59e0b}
 
 /* ===== MEDIA CONTAINER ===== */
 .stack-photo-area, .stack-media-container, .card-media{position:relative;background:#f8fafc}

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -258,7 +258,11 @@ function onMarkerClick(id){
 function renderFeed(){
   const host = document.getElementById("stack-feed");
   host.innerHTML = "";
+  const seenCounts = JSON.parse(localStorage.getItem("stackPhotoCounts") || "{}");
+  const newCounts = {};
   photoStacks.forEach((stack,i)=>{
+    newCounts[stack.id] = stack.photos.length;
+    const hasNew = stack.photos.length > (seenCounts[stack.id] || 0);
     const card = document.createElement("div");
     card.className = `stack-card${stack.id===activeStackId?' active':''}`;
     card.id = stack.id; card.dataset.stackId = stack.id; card.tabIndex = 0;
@@ -268,6 +272,7 @@ function renderFeed(){
       <div class="stack-card-header">
         ${stack.title ? `<h2 class="stack-card-title">${escapeHtml(stack.title)}</h2>` : ''}
         <div class="stack-location-time">${stack.location.label} • ${t}</div>
+        ${hasNew ? '<span class="new-photo-bell" aria-label="New photos">🔔</span>' : ''}
       </div>
       ${stack.caption ? `<p class="caption">${escapeHtml(stack.caption)}</p>` : ''}
 
@@ -391,6 +396,7 @@ function renderFeed(){
     bindStackInteractions(stack.id, interactionsBlock);
     loadStackInteractions(stack.id, interactionsBlock);
   });
+  localStorage.setItem("stackPhotoCounts", JSON.stringify(newCounts));
 }
 
 // ----- Stack Interactions Helpers -----


### PR DESCRIPTION
## Summary
- highlight stacks with new photos since last visit using a bell indicator
- style bell icon in stack card headers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7142e5c908323b1b2f645ceb9b8a0