### PR TITLE
Initialize admin map on load

### DIFF
--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -98,6 +98,8 @@ function ensureAdminMap() {
       scrollWheelZoom: true,
       touchZoom: true
     });
+    // Show a world view until specific photo coordinates are available
+    adminMap.setView([0, 0], 2);
 
     // Primary: Esri imagery; Fallback: OSM tiles if Esri errors/rate-limits
     const esri = L.tileLayer(
@@ -258,6 +260,8 @@ function renderTripsTab(panel) {
   mapEl.style.height = '40vh';
   mapEl.style.marginTop = '1rem';
   panel.appendChild(mapEl);
+  // Initialize map so users see a base layer immediately
+  ensureAdminMap();
 
   const galleryEl = document.createElement('div');
   galleryEl.id = 'admin-gallery';


### PR DESCRIPTION
## Summary
- Initialize admin map when the Trips tab mounts so the base map is visible
- Default the map to a world view until photo coordinates are loaded

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7258fa0b483238142cf0e9d4b77af