### PR TITLE
Style filenames as secondary meta

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -226,7 +226,13 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 .photo-counter{position:absolute;right:14px;bottom:14px;color:#fff;background:rgba(0,0,0,.55);padding:6px 10px;border-radius:999px;font-weight:700;font-size:.82rem}
 
 /* ===== CAPTION ===== */
-.caption{padding:10px 14px 2px;color:#1f2937;line-height:1.55;font-size:.95rem}
+.caption{
+  padding:6px 14px 0;
+  color:var(--muted-2);
+  line-height:1.4;
+  font-size:.85rem;
+  font-style:italic;
+}
 
 /* ===== ACTIONS BAR ===== */
 .stack-actions, .card-actions{display:flex;justify-content:space-between;align-items:center;padding:10px 12px;border-top:1px solid var(--border);background:#fafbfc}
@@ -827,9 +833,16 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
   transform: none;
 }
 
-.photo-caption {
+.photo-title {
   margin: 12px 0 0 0;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.photo-caption {
+  margin: 4px 0 0 0;
   color: var(--muted-2);
+  font-size: 0.9rem;
   font-style: italic;
 }
 

--- a/public/day.html
+++ b/public/day.html
@@ -58,7 +58,8 @@
     <aside id="lightbox-panel">
       <div id="lightbox-info">
         <div id="lightbox-counter"></div>
-        <div id="lightbox-caption"></div>
+        <div id="lightbox-title" class="photo-title"></div>
+        <div id="lightbox-caption" class="photo-caption"></div>
       </div>
     </aside>
 

--- a/public/js/day.js
+++ b/public/js/day.js
@@ -339,7 +339,7 @@ function renderPhotoPost() {
   const captionWrap = document.getElementById('photo-caption-container');
   if (main.title) {
     const t = document.createElement('p');
-    t.className = 'photo-caption';
+    t.className = 'photo-title';
     t.textContent = main.title;
     captionWrap.appendChild(t);
   }
@@ -390,7 +390,16 @@ function openLightbox(index = 0) {
     vid.style.display = 'none';
   }
 
-  document.getElementById('lightbox-caption').textContent = item.caption || item.title || '';
+  const titleEl = document.getElementById('lightbox-title');
+  const captionEl = document.getElementById('lightbox-caption');
+  if (titleEl) {
+    titleEl.textContent = item.title || '';
+    titleEl.style.display = item.title ? '' : 'none';
+  }
+  if (captionEl) {
+    captionEl.textContent = item.caption || '';
+    captionEl.style.display = item.caption ? '' : 'none';
+  }
   document.getElementById('lightbox-counter').textContent = `${currentPhotoIndex + 1} / ${dayData.photos.length}`;
 
   lb.classList.add('open');

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -381,7 +381,7 @@ function renderFeed(){
       // Add captions
       if (mainPhoto.title) {
         const t = document.createElement('p');
-        t.className = 'photo-caption';
+        t.className = 'photo-title';
         t.textContent = mainPhoto.title;
         mainContainer.appendChild(t);
       }


### PR DESCRIPTION
## Summary
- Render photo titles prominently and show file names as a muted meta line
- Add lightbox markup and styling to separate titles from file names
- Make stack captions less obtrusive

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8451ad7f08323a0478e5422abd81b