### PR TITLE
style: refine thumbnail overlay cluster

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -838,6 +838,11 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
   bottom: 16px;
   right: 16px;
   display: flex;
+  padding: 4px;
+  background: rgba(0,0,0,0.45);
+  backdrop-filter: blur(4px);
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.25);
 }
 
 .thumbnail {
@@ -849,7 +854,7 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
   box-shadow: 0 2px 8px rgba(0,0,0,0.3);
   cursor: pointer;
   transition: transform 0.2s ease, opacity 0.2s ease;
-  opacity: 0.9;
+  opacity: 0.95;
   margin-left: -16px;
 }
 
@@ -865,7 +870,7 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 .more-photos {
   width: 60px;
   height: 60px;
-  background: rgba(0,0,0,0.6);
+  background: linear-gradient(135deg, rgba(0,0,0,0.6), rgba(0,0,0,0.3));
   border: 2px solid #fff;
   border-radius: 8px;
   display: flex;
@@ -880,7 +885,7 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 }
 
 .more-photos:hover {
-  background: rgba(0,0,0,0.8);
+  background: linear-gradient(135deg, rgba(0,0,0,0.8), rgba(0,0,0,0.6));
 }
 
 .photo-actions {


### PR DESCRIPTION
## Summary
- enhance photo thumbnail overlay with blurred backdrop and rounded corners
- add gradient styling to "+more" overlay for a premium look

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8457b36948323b457c6559de92f05