### PR TITLE
style: add neutral surface to photo view

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -812,13 +812,17 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 
 .photo-main {
   position: relative;
+  background: var(--card);
+  padding: 4px;
+  border-radius: 12px;
+  box-shadow: var(--shadow-1);
 }
 
 .photo-main-media {
   width: 100%;
   max-height: 500px;
   object-fit: cover;
-  border-radius: 12px;
+  border-radius: 8px;
   cursor: pointer;
   transition: transform 0.2s ease;
 }


### PR DESCRIPTION
## Summary
- present day view image on neutral surface with subtle shadow and rounded corners

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8455a84688323ad1a368a3051cd7d