### PR TITLE
Ensure lightbox photos fill the screen

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -345,13 +345,23 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 .lb-portal { position:fixed; inset:0; z-index:9999; display:none; }
 .lb-portal.on { display:block; }
 .lb-backdrop { position:absolute; inset:0; background:rgba(0,0,0,.85); }
-.lb-frame { position:absolute; inset:4% 6%; background:rgba(10,10,10,.85); border-radius:12px; border:1px solid rgba(255,255,255,.08); display:grid; grid-template-columns: 1fr minmax(280px, 340px); gap:0; overflow:hidden; }
+.lb-frame {
+  position:absolute;
+  inset:0;
+  background:rgba(10,10,10,.85);
+  border-radius:0;
+  border:0;
+  display:grid;
+  grid-template-columns: 1fr minmax(280px, 340px);
+  gap:0;
+  overflow:hidden;
+}
 .lb-img,
 .lb-video {
   max-width:100%;
   max-height:100%;
-  width:auto;
-  height:auto;
+  width:100%;
+  height:100%;
   object-fit:contain;
   grid-column:1/2;
   grid-row:1/2;
@@ -366,13 +376,17 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 
 /* --- Lightbox right panel --- */
 .lb-panel{
-  position: absolute; right: 0; top: 0; bottom: 0;
-  width: 380px; max-width: 90vw;
+  width: 380px;
+  max-width: 90vw;
+  height: 100%;
   background: rgba(15,15,15,.9);
   border-left: 1px solid rgba(255,255,255,.12);
-  display: grid; grid-template-rows: auto 1fr auto;
-  gap: 12px; padding: 16px;
-  color:#e5e7eb; z-index: 10000;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 12px;
+  padding: 16px;
+  color:#e5e7eb;
+  z-index: 10000;
 }
 
 .lb-toolbar{ display:flex; gap:8px; align-items:center; }


### PR DESCRIPTION
## Summary
- Remove lightbox frame margins and borders so media spans the full viewport
- Scale images and videos to occupy available space
- Position the info panel as a grid column rather than overlay

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8461805cc83239f9dfd2d151929c9