### PR TITLE
Default stack title to admin title or date

### DIFF
--- a/public/js/day.js
+++ b/public/js/day.js
@@ -1,4 +1,4 @@
-import { dataUrl, getApiBase, haversineKm, escapeHtml, formatTime, formatDateTime, groupIntoStacks } from "./utils.js";
+import { dataUrl, getApiBase, haversineKm, escapeHtml, formatTime, formatDateTime, groupIntoStacks, formatDate } from "./utils.js";
 
 // Get date from URL parameter
 const urlParams = new URLSearchParams(window.location.search);
@@ -66,7 +66,7 @@ async function renderStacksSection() {
 
   for (const st of stacks) {
     const meta = (dayData.stackMeta && dayData.stackMeta[st.id]) || { title: '', caption: '' };
-    const title = meta.title?.trim() || 'Untitled stop';
+    const title = meta.title?.trim() || formatDate(st.photos[0]?.taken_at);
     const caption = meta.caption?.trim() || '';
 
     // Card shell

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,4 +1,4 @@
-import { dataUrl, getApiBase, groupIntoStacks, debounce, urlParam, pushUrlParam, replaceUrlParam, fmtTime, escapeHtml } from "./utils.js";
+import { dataUrl, getApiBase, groupIntoStacks, debounce, urlParam, pushUrlParam, replaceUrlParam, fmtTime, escapeHtml, formatDate } from "./utils.js";
 
 const isMobile = matchMedia('(max-width:768px)').matches;
 let topMap; // no mini-map when sticky hero map is always visible
@@ -184,7 +184,8 @@ async function loadStacks(){
     dayStackCounters[slug] = idx + 1;
     const metaKey = `stack-${idx}`;
     const meta = stackMetaByDay[slug]?.[metaKey];
-    if (meta?.title) s.title = meta.title;
+    const title = meta?.title?.trim();
+    s.title = title || formatDate(s.takenAt);
     s.caption = meta?.caption || '';
     s.photos.forEach(p => p.stackId = s.id);
   });

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -109,7 +109,7 @@ export function groupIntoStacks(photos, radiusMeters = 500) {
     const id = `stack-${seq++}`;
     const s = {
       id,
-      title: first.caption || first.dayTitle,
+      title: '',
       location: loc,
       photos: [],
       takenAt: first.taken_at || first.takenAt || first.ts || null,
@@ -215,6 +215,11 @@ export function escapeHtml(text) {
 export function formatTime(iso) {
   if (!iso) return '';
   return new Date(iso).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
+}
+
+export function formatDate(iso) {
+  if (!iso) return '';
+  return new Date(iso).toLocaleDateString();
 }
 
 export function formatDateTime(iso) {


### PR DESCRIPTION
## Summary
- Ensure stack title uses admin-provided title or falls back to photo date
- Display stack titles on day view and feed using fallback date
- Add `formatDate` utility and remove caption-based default titles in stack grouping

## Testing
- `npm test` *(fails: Missing script "test" in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a848caf0c88323b79779a017629ecc