### PR TITLE
feat: expand top map to full screen

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -23,19 +23,19 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 /* ===== STICKY HERO MAP ===== */
 /* Sticky hero map */
 .top-map-wrap{
-  position: sticky;
-  top: 0;                     /* pin to top */
+  position: relative;
+  top: 0;
   z-index: 40;
-  padding: 8px 0;
-  background: #0b1020;        /* or your page bg, prevents content "jump" */
+  padding: 0;
 }
 
-/* Short, mobile-first height. On desktop it grows a bit. */
+/* Fullscreen map */
 .top-map{
-  height: clamp(160px, 28vh, 300px);
-  border-radius: 12px;
+  height: 100vh;
+  width: 100%;
+  border-radius: 0;
   overflow: hidden;
-  box-shadow: 0 4px 20px rgba(0,0,0,.2);
+  box-shadow: none;
 }
 
 /* Make sure the map's container doesn't fight scrolling on mobile */

--- a/public/index.html
+++ b/public/index.html
@@ -8,19 +8,19 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 </head>
 <body>
-  <!-- Header -->
-  <header class="trip-header">
-    <div class="container">
-      <h1 class="trip-title">My Trip — Photo Journey</h1>
-    </div>
-  </header>
-
-  <!-- Top map that stays at the top -->
+  <!-- Fullscreen top map -->
   <section class="top-map-wrap">
     <div id="top-map" class="top-map"></div>
     <!-- Optional expand button on mobile -->
     <button class="map-expand" aria-label="Expand map">🗺️</button>
   </section>
+
+  <!-- Header below map -->
+  <header class="trip-header">
+    <div class="container">
+      <h1 class="trip-title">My Trip — Photo Journey</h1>
+    </div>
+  </header>
 
   <!-- Sticky Mini-Map -->
   <div id="mini-map-container" class="mini-map-container hidden">


### PR DESCRIPTION
## Summary
- move dashboard header below map and make the map element fullscreen
- remove sticky constraints and radius so map fills entire viewport

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8478efac88323abfd149add5ece52