### PR TITLE
Make lightbox image fullscreen with vignette backdrop

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -344,14 +344,24 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 /* lightbox shell */
 .lb-portal { position:fixed; inset:0; z-index:9999; display:none; }
 .lb-portal.on { display:block; }
-.lb-backdrop { position:absolute; inset:0; background:rgba(0,0,0,.85); }
-.lb-frame { position:absolute; inset:4% 6%; background:rgba(10,10,10,.85); border-radius:12px; border:1px solid rgba(255,255,255,.08); display:grid; grid-template-columns: 1fr minmax(280px, 340px); gap:0; overflow:hidden; }
+.lb-backdrop {
+  position:absolute;
+  inset:0;
+  background:radial-gradient(circle at center, rgba(0,0,0,.4) 0%, rgba(0,0,0,.85) 80%);
+}
+.lb-frame {
+  position:absolute;
+  inset:0;
+  background:transparent;
+  display:grid;
+  grid-template-columns: 1fr minmax(280px, 340px);
+  gap:0;
+  overflow:hidden;
+}
 .lb-img,
 .lb-video {
-  max-width:100%;
-  max-height:100%;
-  width:auto;
-  height:auto;
+  width:100%;
+  height:100%;
   object-fit:contain;
   grid-column:1/2;
   grid-row:1/2;


### PR DESCRIPTION
## Summary
- Expand lightbox to fill the viewport and stretch images edge-to-edge
- Add radial-gradient backdrop for a subtle vignette effect

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8466bc5b88323900f72920c8fe6fc