### PR TITLE
Fix video playback in stack view

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1267,9 +1267,8 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
   border-radius:12px;
 }
 
-/* Videos in stacks are disabled from playing - no controls or interaction */
+/* Videos in stacks should not show controls but remain interactive for lightbox */
 .stack-main-photo video {
-  pointer-events: none;
   background: #000;
 }
 


### PR DESCRIPTION
## Summary
- ensure video elements can autoplay and trigger lightbox
- keep stack view videos interactive by removing pointer-event override

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8ca87e3948323b811cf6b71338b68