### PR TITLE
Move stack titles under photos

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1028,7 +1028,7 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 }
 
 /* Ensure seamless integration - no spacing between header and media */
-.stack-card .stack-card-header + .stack-photo-area {
+.stack-card .stack-photo-area + .stack-card-header {
   margin-top: 0 !important;
   border-top: none !important;
 }

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -330,13 +330,6 @@ function renderFeed(){
 
     const t = fmtTime(stack.takenAt);
     card.innerHTML = `
-      <div class="stack-card-header">
-        ${stack.title ? `<h2 class="stack-card-title">${escapeHtml(stack.title)}</h2>` : ''}
-        <div class="stack-location-time">${stack.location.label} • ${t}</div>
-        ${hasNew ? '<span class="new-photo-bell" aria-label="New photos">🔔</span>' : ''}
-      </div>
-      ${stack.caption ? `<p class="caption">${escapeHtml(stack.caption)}</p>` : ''}
-
       <div class="stack-photo-area" data-stack-id="${stack.id}">
         <div class="stack-media-container">
           <div class="photo-main" data-main-container="${stack.id}"></div>
@@ -351,6 +344,13 @@ function renderFeed(){
             <button class="thumb-scroll right" aria-label="Scroll thumbnails right">›</button>
           </div>` : ``}
       </div>
+
+      <div class="stack-card-header">
+        ${stack.title ? `<h2 class="stack-card-title">${escapeHtml(stack.title)}</h2>` : ''}
+        <div class="stack-location-time">${stack.location.label} • ${t}</div>
+        ${hasNew ? '<span class="new-photo-bell" aria-label="New photos">🔔</span>' : ''}
+      </div>
+      ${stack.caption ? `<p class="caption">${escapeHtml(stack.caption)}</p>` : ''}
 
       <!-- PERMANENT inline interactions -->
       <section class="stack-interactions" data-stack-id="${stack.id}">


### PR DESCRIPTION
## Summary
- Place photo area at top of stack card and move title & caption underneath
- Adjust CSS selector so header below media sits flush

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8dc86d3c8832380400f26f0a5f998