### PR TITLE
Add anonymous identity cookie plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Minimal `.env` example:
 IMMICH_URL=https://photos.example.com
 IMMICH_API_KEY=your_api_key
 IMMICH_ALBUM_ID=your_album_id
+ANON_COOKIE_SECRET=long_random_string
 ```
 
 Running the loader for `2025-08-14` with the above settings creates `public/data/days/2025-08-14.json` containing only photos from the specified album.

--- a/anon.js
+++ b/anon.js
@@ -1,0 +1,39 @@
+import crypto from 'crypto';
+
+export function anonPlugin(app, opts, done) {
+  const COOKIE = 'anon';
+  const SECRET = process.env.ANON_COOKIE_SECRET || 'dev-secret-change-me';
+
+  function sign(val) {
+    return crypto.createHmac('sha256', SECRET).update(val).digest('base64url');
+  }
+  function pack(id) { return `${id}.${sign(id)}`; }
+  function unpack(v='') {
+    const [id, sig] = v.split('.', 2);
+    if (!id || !sig) return null;
+    if (sign(id) !== sig) return null;
+    return id;
+  }
+  function newId() {
+    return crypto.randomUUID(); // node >=16.14
+  }
+
+  app.addHook('onRequest', (req, reply, doneHook) => {
+    const raw = req.cookies?.[COOKIE]; // make sure you registered @fastify/cookie
+    let id = unpack(raw);
+    if (!id) {
+      id = newId();
+      reply.setCookie(COOKIE, pack(id), {
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: true,          // set to true in production (https)
+        path: '/',
+        maxAge: 60 * 60 * 24 * 365 * 5, // 5 years
+      });
+    }
+    req.anonId = id;
+    doneHook();
+  });
+
+  done();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@fastify/cors": "^8.4.0",
         "@fastify/static": "^6.12.0",
         "dotenv": "^16.3.1",
-        "fastify": "^4.29.1"
+        "fastify": "^4.29.1",
+        "@fastify/cookie": "^9.3.0"
       }
     },
     "node_modules/@fastify/accept-negotiator": {
@@ -32,6 +33,14 @@
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "fast-uri": "^2.0.0"
+      }
+    },
+    "node_modules/@fastify/cookie": {
+      "version": "9.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.1",
+        "fastify-plugin": "^4.0.0"
       }
     },
     "node_modules/@fastify/cors": {
@@ -213,6 +222,10 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.1",
+      "license": "MIT"
     },
     "node_modules/depd": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@fastify/cors": "^8.4.0",
     "@fastify/static": "^6.12.0",
     "dotenv": "^16.3.1",
-    "fastify": "^4.29.1"
+    "fastify": "^4.29.1",
+    "@fastify/cookie": "^9.3.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -3,6 +3,8 @@
 import fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
 import cors from '@fastify/cors';
+import fastifyCookie from '@fastify/cookie';
+import { anonPlugin } from './anon.js';
 import fs from 'fs/promises';
 import fsSync from 'fs';
 import path from 'path';
@@ -38,6 +40,8 @@ const AUTOLOAD_INTERVAL = 60 * 60 * 1000; // 1 hour
 // helpers
 const app = fastify({ logger: true });
 app.register(cors, { origin: true });
+app.register(fastifyCookie, { secret: process.env.ANON_COOKIE_SECRET });
+app.register(anonPlugin);
 
 // serve /public so /day.html, /js/day.js, /css etc. work
 // Use REPO_DIR to ensure correct static root even when the working directory differs


### PR DESCRIPTION
## Summary
- implement anon cookie plugin with signed random IDs
- wire up Fastify cookie and anon plugin registration
- document ANON_COOKIE_SECRET env variable

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e4aa2ce883238a97f2fe91ac5098