### PR TITLE
Remove photo filename from stack main images

### DIFF
--- a/public/js/day.js
+++ b/public/js/day.js
@@ -343,14 +343,8 @@ function renderPhotoPost() {
     mainEl.addEventListener('click', () => openLightbox(0));
   }
 
-  // Captions
+  // Caption
   const captionWrap = document.getElementById('photo-caption-container');
-  if (main.title) {
-    const t = document.createElement('p');
-    t.className = 'photo-title';
-    t.textContent = main.title;
-    captionWrap.appendChild(t);
-  }
   if (main.caption) {
     const c = document.createElement('p');
     c.className = 'photo-caption';

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -414,13 +414,7 @@ function renderFeed(){
       mainEl.style.cursor = 'zoom-in';
       mainEl.addEventListener('click', () => openLightboxForStack(stack, current));
       
-      // Add captions
-      if (mainPhoto.title) {
-        const t = document.createElement('p');
-        t.className = 'photo-title';
-        t.textContent = mainPhoto.title;
-        mainContainer.appendChild(t);
-      }
+      // Add caption if available
       if (mainPhoto.caption) {
         const c = document.createElement('p');
         c.className = 'photo-caption';


### PR DESCRIPTION
## Summary
- Hide photo file names beneath stack's primary image on main index page
- Stop rendering photo titles beneath the main photo on day pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8f2f7c3508323876c4ca5c1c18062