### PR TITLE
Style comments panel with padding and subtle border

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1655,6 +1655,14 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 }
 
 /* --- Modern comments block --- */
+.comments-panel {
+  --pad-x: 24px;
+  --divider: rgba(255,255,255,.10);
+  padding-inline: var(--pad-x);
+  border: 1px solid var(--divider);
+  box-shadow: none;
+  border-radius: 14px;
+}
 .comments-block{
   margin: 0.75rem 0 1rem;
   padding: 0.75rem 0;


### PR DESCRIPTION
## Summary
- add `.comments-panel` rules with 24px horizontal padding
- remove neon glow, leaving a thin divider border

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a97605d5c0832396fb84e07d409acb