### PR TITLE
Refine reverse geocoding output

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -29,7 +29,12 @@ async function reverseGeocode(lat, lon) {
     const res = await fetch(url);
     if (res.ok) {
       const data = await res.json();
-      const name = data.display_name || `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
+      const addr = data.address || {};
+      const city = addr.city || addr.town || addr.village || addr.hamlet;
+      const region = addr.state || addr.region || addr.province || addr.state_district;
+      const country = addr.country;
+      const nameParts = [region, city, country].filter(Boolean);
+      const name = nameParts.length ? nameParts.join(', ') : `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
       geocodeCache[key] = name;
       localStorage.setItem(GEO_CACHE_KEY, JSON.stringify(geocodeCache));
       return name;


### PR DESCRIPTION
## Summary
- Format reverse geocoding results to show only region, city, and country

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a976dfb38c832399cefeb20729960b