### PR TITLE
Add expandable hero thumbnail carousel

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -260,6 +260,7 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
   background: rgba(0,0,0,.45);
   backdrop-filter: blur(6px);
   box-shadow: 0 8px 24px rgba(0,0,0,.25);
+  overflow: hidden;
 }
 
 .thumb-rail.expanded {
@@ -300,7 +301,6 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
   object-fit: contain;
 }
 .rail-thumb:hover { transform: scale(1.03); opacity: 1; }
-.rail-thumb.active { border-color: var(--accent); outline:2px solid var(--accent); outline-offset:2px; opacity: 1; }
 
 .rail-track.dragging {
   cursor: grabbing;
@@ -1925,39 +1925,17 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
   font-weight: 400;
 }
 
-.photo-thumbnails {
-  position: absolute;
-  bottom: 16px;
-  right: 16px;
-  display: flex;
-  padding: 4px;
-  background: rgba(0,0,0,0.45);
-  backdrop-filter: blur(4px);
-  border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.25);
-}
+/* thumbnail rail peek adjustments */
+.rail-track .rail-thumb:first-child { margin-left: -8px; }
+.rail-track .rail-thumb:last-child { margin-right: -8px; }
 
-/* Legacy thumbnail styles - now handled by main thumbnail styles */
+.rail-thumb:focus-visible { outline: 2px solid #fff; }
 
-.more-photos {
-  width: 60px;
-  height: 60px;
-  background: linear-gradient(135deg, rgba(0,0,0,0.6), rgba(0,0,0,0.3));
-  border: 2px solid #fff;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #fff;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.2s ease;
-  margin-left: -16px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-}
-
-.more-photos:hover {
-  background: linear-gradient(135deg, rgba(0,0,0,0.8), rgba(0,0,0,0.6));
+.rail-thumb.active {
+  border-color: var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  transform: scale(1.03);
 }
 
 .photo-actions {
@@ -2086,13 +2064,13 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 
 /* Video and Image consistent styling */
 .photo-main img, .photo-main video,
-.photo-thumbnails img, .photo-thumbnails video,
 .media-tile {
   display:block;
   width:100%;
   object-fit:contain;
   border-radius:12px;
 }
+
 
 /* Videos in stacks are disabled from playing - no controls or interaction */
 .stack-main-photo video {

--- a/public/js/day.js
+++ b/public/js/day.js
@@ -11,6 +11,8 @@ if (!daySlug) {
 
 let dayData = null;
 let map = null;
+let mainWrap = null;
+let thumbStrip = null;
 
 // ---------- media helpers ----------
 function isVideo(item) {
@@ -311,37 +313,97 @@ function renderPhotoPost() {
   `;
   container.innerHTML = headerHtml;
 
-  // Main media
-  const mainWrap = document.getElementById('photo-main');
-  const mainEl = renderMediaEl(main, { withControls: isVideo(main), className: 'photo-main-media' });
-  mainWrap.appendChild(mainEl);
+  // Main media container
+  mainWrap = document.getElementById('photo-main');
 
-  // Thumbnails overlay
+  // Floating thumbnail rail
   if (items.length > 1) {
-    const thumbs = document.createElement('div');
-    thumbs.id = 'photo-thumbs';
-    thumbs.className = 'photo-thumbnails';
-    mainWrap.appendChild(thumbs);
-    const thumbItems = items.slice(1, 5);
-    thumbItems.forEach((it, idx) => {
-      const el = renderMediaEl(it, { withControls: false, className: 'thumbnail' });
-      el.addEventListener('click', () => openLightbox(idx + 1));
-      thumbs.appendChild(el);
+    const rail = document.createElement('div');
+    rail.className = 'thumb-rail';
+
+    const prevBtn = document.createElement('button');
+    prevBtn.className = 'rail-nav prev';
+    prevBtn.textContent = '‹';
+
+    const nextBtn = document.createElement('button');
+    nextBtn.className = 'rail-nav next';
+    nextBtn.textContent = '›';
+
+    const expandBtn = document.createElement('button');
+    expandBtn.className = 'rail-expand';
+    expandBtn.textContent = '⇵';
+
+    const track = document.createElement('div');
+    track.className = 'rail-track';
+
+    items.forEach((it, idx) => {
+      const el = renderMediaEl(it, { withControls: false, className: 'rail-thumb', useThumb: true });
+      el.tabIndex = 0;
+      el.addEventListener('click', () => { showMainPhoto(idx); openLightbox(idx); });
+      el.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          showMainPhoto(idx);
+          openLightbox(idx);
+        }
+      });
+      track.appendChild(el);
     });
-    if (items.length > 5) {
-      const more = document.createElement('div');
-      more.className = 'more-photos';
-      more.textContent = `+${items.length - 5}`;
-      more.addEventListener('click', () => openLightbox(5));
-      thumbs.appendChild(more);
-    }
+
+    rail.appendChild(prevBtn);
+    rail.appendChild(track);
+    rail.appendChild(nextBtn);
+    rail.appendChild(expandBtn);
+    mainWrap.appendChild(rail);
+    thumbStrip = track;
+
+    const scrollBy = (dir) => {
+      track.scrollBy({ left: dir * track.clientWidth * 0.9, behavior: 'smooth' });
+    };
+    prevBtn.addEventListener('click', () => scrollBy(-1));
+    nextBtn.addEventListener('click', () => scrollBy(1));
+
+    const updateNav = () => {
+      prevBtn.disabled = track.scrollLeft <= 0;
+      nextBtn.disabled = track.scrollLeft + track.clientWidth >= track.scrollWidth - 1;
+    };
+    track.addEventListener('scroll', updateNav);
+    updateNav();
+
+    expandBtn.addEventListener('click', () => {
+      rail.classList.toggle('expanded');
+    });
+
+    // Drag to scroll
+    let drag = false, startX = 0, startScroll = 0;
+    track.addEventListener('pointerdown', (e) => {
+      drag = true;
+      startX = e.clientX;
+      startScroll = track.scrollLeft;
+      track.classList.add('dragging');
+      track.setPointerCapture(e.pointerId);
+    });
+    track.addEventListener('pointermove', (e) => {
+      if (!drag) return;
+      const dx = e.clientX - startX;
+      track.scrollLeft = startScroll - dx;
+    });
+    const stopDrag = () => {
+      drag = false;
+      track.classList.remove('dragging');
+    };
+    track.addEventListener('pointerup', stopDrag);
+    track.addEventListener('pointercancel', stopDrag);
+
+    track.addEventListener('wheel', (e) => {
+      if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+        track.scrollBy({ left: e.deltaY, behavior: 'smooth' });
+        e.preventDefault();
+      }
+    });
   }
 
-  // Click to open lightbox for images; videos keep controls/play
-  if (!isVideo(main)) {
-    mainEl.style.cursor = 'zoom-in';
-    mainEl.addEventListener('click', () => openLightbox(0));
-  }
+  showMainPhoto(0);
 
   // Captions
   const captionWrap = document.getElementById('photo-caption-container');
@@ -356,6 +418,29 @@ function renderPhotoPost() {
     c.className = 'photo-caption';
     c.textContent = main.caption;
     captionWrap.appendChild(c);
+  }
+}
+
+function showMainPhoto(index) {
+  if (!dayData?.photos?.length || !mainWrap) return;
+  currentPhotoIndex = Math.max(0, Math.min(index, dayData.photos.length - 1));
+  const item = dayData.photos[currentPhotoIndex];
+  const newEl = renderMediaEl(item, { withControls: isVideo(item), className: 'photo-main-media' });
+  const old = mainWrap.querySelector('.photo-main-media');
+  if (old) {
+    mainWrap.replaceChild(newEl, old);
+  } else {
+    mainWrap.appendChild(newEl);
+  }
+  if (!isVideo(item)) {
+    newEl.style.cursor = 'zoom-in';
+    newEl.addEventListener('click', () => openLightbox(currentPhotoIndex));
+  }
+  if (thumbStrip) {
+    const thumbs = thumbStrip.querySelectorAll('.rail-thumb');
+    thumbs.forEach((t, i) => t.classList.toggle('active', i === currentPhotoIndex));
+    const active = thumbs[currentPhotoIndex];
+    if (active) active.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
   }
 }
 
@@ -383,6 +468,7 @@ function openLightbox(index = 0) {
 
   currentPhotoIndex = Math.max(0, Math.min(index, dayData.photos.length - 1));
   const item = dayData.photos[currentPhotoIndex];
+  showMainPhoto(currentPhotoIndex);
 
   console.log('🔍 Opening lightbox for photo:', item);
 


### PR DESCRIPTION
## Summary
- Replace static thumbnail strip with a floating rail that supports scroll-snap, drag/scroll navigation, and edge peeking
- Add prev/next arrows, expandable drawer toggle, and active-state syncing with the lightbox

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8f2d4c55c8323818732ff74a3caf5