### PR TITLE
feat: add comment sort control

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -719,6 +719,9 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
 /* Thread Header */
 .thread-header {
   margin-bottom: .5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .thread-toggle {
@@ -749,7 +752,10 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
   cursor: pointer;
 }
 
-/* Sort options removed */
+/* Sort segmented control */
+.segmented{display:inline-flex;border:1px solid rgba(255,255,255,.12);border-radius:999px;overflow:hidden}
+.segmented button{background:transparent;color:#9aa3b2;padding:6px 12px;border:0;font-weight:700;cursor:pointer}
+.segmented button[aria-pressed="true"]{background:#3b82f6;color:#fff}
 
 /* Thread Container - Completely flat, seamless with page */
 .thread-container {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -393,9 +393,13 @@ function renderFeed(){
         <div class="discussion-thread">
           <div class="thread-header">
             <button class="thread-toggle" type="button" aria-expanded="false">
-              <span class="thread-count">View 0 comments</span>
-          </button>
-      </div>
+              <span class="thread-count">View 0 comments ▾</span>
+            </button>
+            <div class="thread-sort segmented" hidden>
+              <button type="button" data-sort="newest" aria-pressed="true">Newest</button>
+              <button type="button" data-sort="oldest" aria-pressed="false">Oldest</button>
+            </div>
+          </div>
 
           <div class="thread-container" style="display: none;">
             <div class="thread-empty" style="display: none;">
@@ -577,7 +581,8 @@ function initDiscussionState(stackId) {
       comments: [],
       expanded: false,
       manuallyCollapsed: false,
-      activeReplyComposer: null
+      activeReplyComposer: null,
+      sort: 'newest'
     });
   }
   return discussionState.get(stackId);
@@ -665,7 +670,13 @@ function updateThreadCount(stackId, block) {
   const state = discussionState.get(stackId);
   const threadCount = block.querySelector('.thread-count');
   const threadToggle = block.querySelector('.thread-toggle');
+  const sortControl = block.querySelector('.thread-sort');
   const totalComments = state ? countTotalComments(state.comments) : 0;
+
+  if (sortControl) {
+    sortControl.hidden = !(state && state.expanded);
+    if (state) updateSortButtons(stackId, block);
+  }
   
   if (totalComments === 0) {
     threadCount.textContent = 'Add a comment';
@@ -691,6 +702,16 @@ function updateThreadCount(stackId, block) {
       threadToggle.classList.remove('expanded');
     }
   }
+}
+
+// Update active state of sort buttons
+function updateSortButtons(stackId, block) {
+  const state = discussionState.get(stackId);
+  const sortControl = block.querySelector('.thread-sort');
+  if (!state || !sortControl) return;
+  sortControl.querySelectorAll('button').forEach(btn => {
+    btn.setAttribute('aria-pressed', btn.dataset.sort === state.sort);
+  });
 }
 
 // Count total comments including replies (recursive for unlimited depth)
@@ -725,10 +746,11 @@ function bindLikeInteractions(stackId, block) {
 // Bind discussion thread interactions
 function bindDiscussionThread(stackId, block) {
   const state = initDiscussionState(stackId);
-  
+
   // Thread toggle
   const threadToggle = block.querySelector('.thread-toggle');
   const threadContainer = block.querySelector('.thread-container');
+  const sortControl = block.querySelector('.thread-sort');
   
   if (!threadToggle || !threadContainer) {
     console.error('❌ Missing required thread elements for stack:', stackId);
@@ -753,6 +775,23 @@ function bindDiscussionThread(stackId, block) {
     // Update the thread count text based on new state
     updateThreadCount(stackId, block);
   });
+
+  // Sort control
+  if (sortControl) {
+    sortControl.addEventListener('click', (e) => {
+      if (e.target.tagName === 'BUTTON') {
+        const sort = e.target.dataset.sort;
+        if (sort && state.sort !== sort) {
+          state.sort = sort;
+          updateSortButtons(stackId, block);
+          renderThreadedComments(stackId, block);
+        }
+      }
+    });
+
+    // Initialize sort buttons
+    updateSortButtons(stackId, block);
+  }
   
   // Main comment composer
   bindCommentComposer(stackId, block);
@@ -881,8 +920,12 @@ function renderThreadedComments(stackId, block) {
   
   emptyState.style.display = 'none';
   
-  // Display comments in chronological order (newest first)
-  const sortedComments = [...state.comments].sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+  // Display comments based on selected sort order
+  const sortedComments = [...state.comments].sort((a, b) => {
+    return state.sort === 'newest'
+      ? new Date(b.timestamp) - new Date(a.timestamp)
+      : new Date(a.timestamp) - new Date(b.timestamp);
+  });
   
   // Render each comment thread with staggered animation
   sortedComments.forEach((comment, index) => {


### PR DESCRIPTION
## Summary
- show "View N comments ▾" when collapsed
- add segmented sort control for newest/oldest comments
- style segmented control and thread header for clarity

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9768511b88323a9b19adc5ebffe32