### PR TITLE
Add load more to day photo grid

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -2662,6 +2662,8 @@ input[placeholder*="comment" i]::placeholder,
 /* Grid of remaining media */
 .stack-grid { display: grid; gap: 6px; grid-template-columns: repeat(auto-fill, minmax(120px,1fr)); padding: 0 14px 10px; }
 .stack-thumb { width: 100%; height: 120px; object-fit: contain; border-radius: 10px; display:block; }
+.stack-load-more { margin: 0 14px 14px; padding: 8px 12px; border: none; background: #f3f4f6; border-radius: 8px; cursor: pointer; font-weight:600; }
+.stack-load-more:hover { background: #e5e7eb; }
 
 /* Footer (likes) */
 .stack-footer {

--- a/public/js/day.js
+++ b/public/js/day.js
@@ -187,26 +187,47 @@ async function renderStacksSection() {
     // Media grid (rest)
     const grid = document.createElement('div');
     grid.className = 'stack-grid';
-    st.photos.forEach((p, idx) => {
-      const el = renderMediaEl(p, { 
-        withControls: false, 
-        className: idx === 0 ? 'stack-cover-media' : 'stack-thumb',
-        useThumb: idx > 0  // Use thumbnails for grid items, full res for cover
+
+    // Cover click opens lightbox
+    const coverPhoto = st.photos[0];
+    if (coverPhoto) {
+      coverWrap.addEventListener('click', () => {
+        const gi = globalIndex.get(coverPhoto.id || coverPhoto.url) ?? 0;
+        openLightbox(gi);
       });
-      if (idx > 0) {
+    }
+
+    const thumbs = st.photos.slice(1);
+    const loadMoreBtn = document.createElement('button');
+    loadMoreBtn.className = 'stack-load-more';
+    loadMoreBtn.textContent = 'Load more photos';
+
+    function renderMore() {
+      const cols = getComputedStyle(grid).gridTemplateColumns.split(' ').length || 1;
+      const batch = cols * 7; // roughly 7 rows
+      const start = grid.childElementCount;
+      const end = Math.min(start + batch, thumbs.length);
+
+      for (let i = start; i < end; i++) {
+        const p = thumbs[i];
+        const el = renderMediaEl(p, {
+          withControls: false,
+          className: 'stack-thumb',
+          useThumb: true
+        });
         el.addEventListener('click', () => {
           const gi = globalIndex.get(p.id || p.url) ?? 0;
           openLightbox(gi);
         });
         grid.appendChild(el);
-      } else {
-        // cover click opens lightbox
-        coverWrap.addEventListener('click', () => {
-          const gi = globalIndex.get(p.id || p.url) ?? 0;
-          openLightbox(gi);
-        });
       }
-    });
+
+      if (grid.childElementCount >= thumbs.length) {
+        loadMoreBtn.remove();
+      }
+    }
+
+    loadMoreBtn.addEventListener('click', renderMore);
 
     // Footer with likes count
     const footer = document.createElement('footer');
@@ -220,9 +241,15 @@ async function renderStacksSection() {
     card.appendChild(coverWrap);
     card.appendChild(header);
     if (caption) card.appendChild(descContainer);
-    if (st.photos.length > 1) card.appendChild(grid);
+    if (thumbs.length > 0) {
+      card.appendChild(grid);
+      card.appendChild(loadMoreBtn);
+    }
     card.appendChild(footer);
     host.appendChild(card);
+    if (thumbs.length > 0) {
+      renderMore();
+    }
 
     // Load interactions & update counts
     (async () => {


### PR DESCRIPTION
## Summary
- add "Load more" control to day page photo grids to reveal additional images in ~7-row batches
- style new load-more button

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aabd8222a0832382ea44ca5b4dcced