### PR TITLE
Add load more to day photo grid

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -2662,6 +2662,8 @@ input[placeholder*="comment" i]::placeholder,
 /* Grid of remaining media */
 .stack-grid { display: grid; gap: 6px; grid-template-columns: repeat(auto-fill, minmax(120px,1fr)); padding: 0 14px 10px; }
 .stack-thumb { width: 100%; height: 120px; object-fit: contain; border-radius: 10px; display:block; }
+.stack-load-more { display:block; margin: 0 auto 14px; padding: 8px 12px; border: none; background: #f3f4f6; border-radius: 8px; cursor: pointer; font-weight:600; }
+.stack-load-more:hover { background: #e5e7eb; }
 
 /* Footer (likes) */
 .stack-footer {


### PR DESCRIPTION
## Summary
- ensure stack load-more button renders an initial batch and only appears when more thumbnails remain
- center load-more control styling

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68aabd8222a0832382ea44ca5b4dcced