### PR TITLE
Show lightbox image fullscreen on mobile

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -2554,9 +2554,10 @@ input[placeholder*="comment" i]::placeholder,
     height: 40px;
     font-size: 20px;
   }
-  
-  .lightbox-prev { left: -50px; }
-  .lightbox-next { right: -50px; }
+
+  /* Keep navigation arrows visible on small screens */
+  .lightbox-prev { left: 10px; }
+  .lightbox-next { right: 10px; }
 }
 
 /* ==== Admin Map Photo Markers ==== */
@@ -2950,85 +2951,101 @@ input[placeholder*="comment" i]::placeholder,
   /* Standard lightbox mobile styles */
   #lightbox.open {
     flex-direction: column;
-    padding: 2vh 2vw;
+    align-items: flex-start;
+    justify-content: flex-start;
+    padding: 0;
+    overflow-y: auto;
   }
-  
+
   #lightbox.open #lightbox-media {
-    border-radius: 16px 16px 0 0;
-    max-width: 90vw;
-    max-height: 60vh;
-    width: 90vw;
+    width: 100vw;
+    height: 100vh;
+    max-width: 100vw;
+    max-height: 100vh;
+    border-radius: 0;
+    padding: 0;
   }
-  
+
   #lightbox.open #lightbox-panel {
-    border-radius: 0 0 16px 16px;
-    max-width: 90vw;
-    max-height: 35vh;
-    width: 90vw;
+    width: 100vw;
+    max-width: 100vw;
+    border-radius: 0;
+    max-height: none;
     border-left: none;
     border-top: 1px solid rgba(255, 255, 255, 0.08);
     padding: 16px;
   }
-  
+
   #lightbox-image,
   #lightbox-video {
+    width: 100%;
+    height: 100%;
     max-width: 100%;
-    max-height: 55vh;
-    border-radius: 8px;
+    max-height: 100%;
+    object-fit: cover;
+    border-radius: 0;
   }
-  
+
   /* Photo-lightbox.js mobile styles */
   .lb-frame {
+    display: flex;
     flex-direction: column;
-    max-width: 95vw;
-    max-height: 95vh;
+    width: 100vw;
+    height: 100vh;
+    max-width: 100vw;
+    max-height: none;
   }
-  
+
   .lb-img,
   .lb-video {
-    max-width: 100%;
-    max-height: 60vh;
-    border-radius: 8px;
-  }
-  
-  .lb-panel {
     width: 100%;
-    max-height: 35vh;
+    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: cover;
+    border-radius: 0;
+  }
+
+  .lb-panel {
+    width: 100vw;
+    max-width: 100vw;
+    border-radius: 0;
+    max-height: none;
     border-left: none;
     border-top: 1px solid rgba(255, 255, 255, 0.08);
     padding: 16px;
   }
-  
-  /* Mobile comments section - limit height on small screens */
+
+  /* Mobile comments section - allow scrolling below full-screen image */
   .lb-comments-section {
-    margin-top: 16px; /* Less padding on mobile */
+    margin-top: 16px;
   }
-  
+
   .lb-comments {
-    max-height: 150px; /* Limit on mobile for better UX */
+    max-height: none;
   }
-  
+
   .lb-toolbar {
     gap: 6px;
     flex-wrap: wrap;
   }
-  
+
   .lb-chip {
     padding: 6px 10px;
     font-size: 13px;
   }
-  
+
   /* Mobile navigation buttons for photo-lightbox.js */
   .lb-nav {
     width: 40px;
     height: 40px;
     font-size: 20px;
   }
-  
+
   .lb-prev {
     left: 10px;
   }
-  
+
   .lb-next {
     right: 10px;
   }


### PR DESCRIPTION
## Summary
- stretch lightbox media to 100vh on phones
- place comments panel below so users scroll down to react

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac667738b48323a54902b9c9285d43