### PR TITLE
Improve mobile lightbox interactions

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -3002,16 +3002,21 @@ input[placeholder*="comment" i]::placeholder,
   .lb-video {
     width: 100%;
     height: 100%;
-
     max-width: 100%;
     max-height: 100%;
-    object-fit: cover;
+    object-fit: contain;
     border-radius: 0;
   }
 
   .lb-panel {
-    width: 100vw;
-    max-width: 100vw;
+    position: static;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
     border-radius: 0;
     max-height: none;
     border-left: none;


### PR DESCRIPTION
## Summary
- Allow pinch-to-zoom and panning on lightbox images, resetting on slide changes
- Scroll comment panel into view on mobile and make comment tools bottom-aligned
- Style lightbox panel for mobile to appear beneath photos

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac78a3f5188323a6c5a3ff4aa6d7ad