### PR TITLE
Avoid reply decoration for local media static files

### DIFF
--- a/server.js
+++ b/server.js
@@ -94,7 +94,8 @@ app.register(fastifyStatic, {
 if (LOCAL_MEDIA_DIR) {
   app.register(fastifyStatic, {
     root: LOCAL_MEDIA_DIR,
-    prefix: '/media/'
+    prefix: '/media/',
+    decorateReply: false
   });
 }
 


### PR DESCRIPTION
## Summary
- avoid redecorating `reply.sendFile` by adding `decorateReply: false` to the local media static server

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b85275a5808323b6e9299786737fc9