### PR TITLE
Fix local media and thumbnail paths

### DIFF
--- a/server.js
+++ b/server.js
@@ -682,18 +682,19 @@ async function getLocalPhotosForDay({ date }) {
         }
         if (t >= start && t < end) {
           const isVideo = video.has(ext);
-          const filename = path.basename(ent.name);
+          const rel = path.relative(LOCAL_MEDIA_DIR, full);
+          const fileId = rel.replace(/[\\/]/g, '_');
           results.push({
-            id: `local_${filename}`,
+            id: `local_${fileId}`,
             kind: isVideo ? 'video' : 'photo',
             mimeType: mime[ext] || (isVideo ? 'video/*' : 'image/*'),
             duration: null,
-            url: `/media/${filename}`,
-            thumb: `/media/thumbs/${filename}`,
+            url: `/media/${rel}`,
+            thumb: `/media/thumbs/${rel}`,
             taken_at: t.toISOString(),
             lat,
             lon,
-            caption: filename
+            caption: path.basename(rel)
           });
         }
       }


### PR DESCRIPTION
## Summary
- Preserve subdirectory paths for locally imported media

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b85cb349d8832387ddbad4efe93f62