### PR TITLE
feat: cache static assets

### DIFF
--- a/server.js
+++ b/server.js
@@ -89,6 +89,8 @@ app.get('/api/user/me', async (req, reply) => {
 app.register(fastifyStatic, {
   root: path.join(REPO_DIR, 'public'),
   prefix: '/', // so /day.html, /admin/index.html, /js/*
+  cacheControl: true,
+  maxAge: '1d',
 });
 
 // expose locally synced media if configured
@@ -96,7 +98,9 @@ if (LOCAL_MEDIA_DIR) {
   app.register(fastifyStatic, {
     root: LOCAL_MEDIA_DIR,
     prefix: '/media/',
-    decorateReply: false
+    decorateReply: false,
+    cacheControl: true,
+    maxAge: '1d',
   });
 }
 


### PR DESCRIPTION
## Summary
- enable cache headers for assets in `public` directory
- enable cache headers for optionally served local media

## Testing
- `curl -I http://localhost:4000/day.html`
- `curl -I -H "If-None-Match: $ETAG" http://localhost:4000/day.html`
- `curl -I http://localhost:4000/media/welcome.html`
- `curl -I -H "If-None-Match: $ETAG2" http://localhost:4000/media/welcome.html`


------
https://chatgpt.com/codex/tasks/task_e_68b86dde6ba08323b735968a525a0573