### PR TITLE
Ensure thumbnails exist for locally stored media

### DIFF
--- a/server.js
+++ b/server.js
@@ -684,13 +684,25 @@ async function getLocalPhotosForDay({ date }) {
           const isVideo = video.has(ext);
           const rel = path.relative(LOCAL_MEDIA_DIR, full);
           const fileId = rel.replace(/[\\/]/g, '_');
+          const localThumb = path.join(LOCAL_MEDIA_DIR, 'thumbs', rel);
+          let thumbUrl = `/media/thumbs/${rel}`;
+          try {
+            await fs.access(localThumb);
+          } catch {
+            await ensureLocalThumb(full, localThumb);
+            try {
+              await fs.access(localThumb);
+            } catch {
+              thumbUrl = `/media/${rel}`;
+            }
+          }
           results.push({
             id: `local_${fileId}`,
             kind: isVideo ? 'video' : 'photo',
             mimeType: mime[ext] || (isVideo ? 'video/*' : 'image/*'),
             duration: null,
             url: `/media/${rel}`,
-            thumb: `/media/thumbs/${rel}`,
+            thumb: thumbUrl,
             taken_at: t.toISOString(),
             lat,
             lon,


### PR DESCRIPTION
## Summary
- verify and generate local 400×400 thumbnails when loading local photos
- fall back to original image when thumbnail creation fails to avoid 404s

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b86dd5c3dc832383ea81c3ae957a0e