### PR TITLE
feat: preload lightbox images

### DIFF
--- a/server.js
+++ b/server.js
@@ -550,7 +550,10 @@ async function ensureLocalThumb(original, thumb) {
         sharp = (await import('sharp')).default;
       }
       await fs.mkdir(path.dirname(thumb), { recursive: true });
-      await sharp(original).resize(400, 400, { fit: 'inside', withoutEnlargement: true }).toFile(thumb);
+      await sharp(original)
+        .rotate()
+        .resize(400, 400, { fit: 'inside', withoutEnlargement: true })
+        .toFile(thumb);
     } catch (err) {
       app.log.error({ msg: 'thumb generation failed', err: String(err) });
     }


### PR DESCRIPTION
## Summary
- Load thumbnail first in lightbox and swap in high-res image when ready
- Preload adjacent images for smoother navigation
- Rotate generated local thumbnails based on EXIF to fix orientation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b86db7d788832398c6f661a4086ccd