### PR TITLE
Parse video metadata from local media

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ FindPenguin/
 ## ⚙️ Configuration
 ### EXIF Metadata
 
-Local photo import uses the [`exifr`](https://www.npmjs.com/package/exifr) library to read timestamps and GPS coordinates from image files. Run `npm install` to install dependencies. Files without EXIF data (or videos) fall back to file modification time and omit location.
+Local media import uses the [`exifr`](https://www.npmjs.com/package/exifr) library to read timestamps and GPS coordinates from image and video files. Run `npm install` to install dependencies. Files without EXIF data fall back to file modification time and omit location.
 
 
 ### Connect to Your Existing Services


### PR DESCRIPTION
## Summary
- Parse EXIF metadata for both photos and videos when scanning local media directories
- Record timestamp, location, and duration (when available) for local videos
- Document that EXIF metadata is read from image and video files

## Testing
- `node --check server.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b98df81fe08323831d82e309aed56a