### PR TITLE
feat: hash static assets and support CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ FindPenguin/
         └── admin.js        # Admin logic (Trips, Blog, Settings tabs)
 ```
 
+## 🗂 Asset Caching and CDN
+
+Static files in `public/` are served with a long cache lifetime (`maxAge` of 1 year).
+To ensure browsers receive updates when files change, the server appends a content hash
+to asset URLs (e.g. `/js/index.js?v=abcd1234`).
+
+If you host assets behind a CDN, set the `CDN_URL` environment variable. When provided,
+all static paths are rewritten to use the CDN domain while retaining the hash query
+parameter.
+
 ## 🚀 How to Run
 
 ### Option A: Local Development (Your Laptop)


### PR DESCRIPTION
## Summary
- cache static assets for 1 year and append content-hash query params
- allow optional CDN_URL to rewrite asset paths
- document asset caching and CDN support

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ba4bb5b6088323988f8158c2dfadec