### PR TITLE
Generate multi-size photo thumbnails and use responsive srcsets

### DIFF
--- a/public/js/day.js
+++ b/public/js/day.js
@@ -119,7 +119,8 @@ function renderMediaEl(item, { withControls = false, className = 'media-tile', u
     const srcsetParts = [];
     if (item.thumb) srcsetParts.push(`${item.thumb} 400w`);
     if (item.variants?.medium) srcsetParts.push(`${item.variants.medium} 800w`);
-    if (item.url) srcsetParts.push(`${item.url} 1600w`);
+    if (item.variants?.large) srcsetParts.push(`${item.variants.large} 1600w`);
+    if (item.url) srcsetParts.push(`${item.url} 2400w`);
     const fullSrcset = srcsetParts.join(', ');
     const sizes = '(max-width: 768px) 100vw, 50vw';
 


### PR DESCRIPTION
## Summary
- Generate 400/800/1600px thumbnails with Sharp
- Provide medium and large variant URLs for photos
- Populate img srcset with new variants for responsive loading

## Testing
- `node --check server.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba4ba7caf08323b344acc836bcb21f