### PR TITLE
Handle optional deps to avoid startup failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .DS_Store
+node_modules/
 
 # Ignore everything in data folders except .gitkeep files
 public/data/days/*

--- a/server.js
+++ b/server.js
@@ -4,18 +4,28 @@ import fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
 import cors from '@fastify/cors';
 import fastifyCookie from '@fastify/cookie';
-import fastifyCompress from '@fastify/compress';
 import { anonPlugin } from './anon.js';
 import fs from 'fs/promises';
 import fsSync from 'fs';
 import path from 'path';
 import dotenv from 'dotenv';
 import crypto from 'crypto';
-import exifr from 'exifr';
 
 dotenv.config();
 
 let sharp;
+let fastifyCompress;
+let exifr;
+try {
+  fastifyCompress = (await import('@fastify/compress')).default;
+} catch (err) {
+  console.warn('⚠️  @fastify/compress not installed, skipping compression');
+}
+try {
+  exifr = (await import('exifr')).default;
+} catch (err) {
+  console.warn('⚠️  exifr not installed, skipping EXIF parsing');
+}
 
 // ---- Config / Paths ---------------------------------------------------------
 const PORT = Number(process.env.PORT) || 4000;
@@ -95,7 +105,9 @@ collectAssetHashes(PUBLIC_DIR);
 const app = fastify({ logger: true });
 app.register(cors, { origin: true });
 app.register(fastifyCookie, { secret: process.env.ANON_COOKIE_SECRET });
-app.register(fastifyCompress);
+if (fastifyCompress) {
+  app.register(fastifyCompress);
+}
 app.register(anonPlugin);
 
 // ---- User Identity ----------------------------------------------------------
@@ -744,7 +756,7 @@ async function getLocalPhotosForDay({ date }) {
         let lon = null;
         let duration = null;
         try {
-          const meta = await exifr.parse(full);
+          const meta = exifr ? await exifr.parse(full) : {};
           if (meta?.DateTimeOriginal) {
             t = new Date(meta.DateTimeOriginal);
           } else if (meta?.CreateDate) {


### PR DESCRIPTION
## Summary
- Guard `@fastify/compress` and `exifr` imports so the server can boot even if the modules aren't installed
- Register the compression plugin only when available
- Ignore `node_modules` in git

## Testing
- `npm test` *(fails: Missing script: "test")*
- `PORT=4000 REPO_DIR=$(pwd) GIT_USER_NAME="Test" GIT_USER_EMAIL="test@example.com" node server.js >/tmp/server.log 2>&1 &`

------
https://chatgpt.com/codex/tasks/task_e_68babdf102c48323b30d7cba37f8aada