### PR TITLE
Ensure anon cookie plugin runs globally

### DIFF
--- a/anon.js
+++ b/anon.js
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
+import fp from 'fastify-plugin';
 
-export function anonPlugin(app, opts, done) {
+export const anonPlugin = fp(function (app, opts, done) {
   const COOKIE = 'anon';
   const SECRET = process.env.ANON_COOKIE_SECRET || 'dev-secret-change-me';
 
@@ -38,4 +39,4 @@ export function anonPlugin(app, opts, done) {
   });
 
   done();
-}
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@fastify/static": "^6.12.0",
         "@fastify/compress": "^8.0.0",
         "dotenv": "^16.3.1",
-        "fastify": "^4.29.1"
+        "fastify": "^4.29.1",
+        "fastify-plugin": "^4.5.1"
       }
     },
     "node_modules/@fastify/accept-negotiator": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dotenv": "^16.3.1",
     "exifr": "^7.1.3",
     "fastify": "^4.29.1",
+    "fastify-plugin": "^4.5.1",
     "sharp": "^0.33.3"
   }
 }


### PR DESCRIPTION
## Summary
- wrap anon cookie plugin with `fastify-plugin` so request hook runs
- add direct dependency on `fastify-plugin`

## Testing
- `npm test` *(fails: Missing script "test")*
- `curl -i http://localhost:4000/api/user/me`


------
https://chatgpt.com/codex/tasks/task_e_68bac5c5f1788323aff4a4df19fa76cb