### PR TITLE
Fix 502 error by polyfilling fetch for older Node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,70 @@
         "@fastify/compress": "^8.0.0",
         "dotenv": "^16.3.1",
         "fastify": "^4.29.1",
-        "fastify-plugin": "^4.5.1"
+        "fastify-plugin": "^4.5.1",
+        "node-fetch": "^3.3.2"
       }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "",
+      "license": "MIT",
+      "engines": { "node": ">=12" }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": { "node": "^12.20 || >=14.13" }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "",
+      "license": "MIT",
+      "dependencies": { "fetch-blob": "^3.1.2" },
+      "engines": { "node": ">=12.20.0" }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.2.tgz",
+      "integrity": "",
+      "license": "MIT",
+      "engines": { "node": ">=8" }
     },
     "node_modules/@fastify/accept-negotiator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "exifr": "^7.1.3",
     "fastify": "^4.29.1",
     "fastify-plugin": "^4.5.1",
+    "node-fetch": "^3.3.2",
     "sharp": "^0.33.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -11,6 +11,15 @@ import path from 'path';
 import dotenv from 'dotenv';
 import crypto from 'crypto';
 
+// Polyfill global fetch on Node.js environments that lack it (e.g. Node <18)
+if (!globalThis.fetch) {
+  try {
+    globalThis.fetch = (await import('node-fetch')).default;
+  } catch (err) {
+    console.warn('⚠️  node-fetch not installed, fetch API unavailable');
+  }
+}
+
 dotenv.config();
 
 let sharp;


### PR DESCRIPTION
## Summary
- polyfill global `fetch` using `node-fetch` so server works on Node.js < 18
- add `node-fetch` runtime dependency and lockfile entries

## Testing
- `npm start >/tmp/server.log 2>&1 &`
- `curl -I http://localhost:4000/`


------
https://chatgpt.com/codex/tasks/task_e_68bac836166083238249a73dcdb438db