### PR TITLE
Add upstream fetch timeout to prevent proxy 502

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Since the admin calls your Immich/Dawarich directly, enable CORS on both:
 - Scheduling: there is no built-in scheduler. Run the loader manually or via an external cron job; each run processes one day and will overwrite that day's file on subsequent runs.
 - `ADMIN_TOKEN` (optional): protects admin endpoints. If set, the import button and other admin actions send this token in an `x-admin-token` header.
 - `LOCAL_MEDIA_DIR` (optional): absolute path to a folder of synced media. When set, imported photos point to `/media/` URLs instead of proxying through Immich. Missing thumbnails are generated on demand into a `thumbs/` subfolder using [`sharp`](https://sharp.pixelplumbing.com/).
+- `FETCH_TIMEOUT` (optional): milliseconds to wait for responses from external services like Immich. Defaults to `15000`.
 
 Minimal `.env` example:
 
@@ -182,6 +183,7 @@ IMMICH_ALBUM_ID=your_album_id
 ADMIN_TOKEN=changeme # required for admin actions like importing
 ANON_COOKIE_SECRET=long_random_string
 LOCAL_MEDIA_DIR=/srv/immich-album
+FETCH_TIMEOUT=15000
 
 # Or multiple servers:
 # IMMICH_URLS=https://immich-one.example.com,https://immich-two.example.com


### PR DESCRIPTION
## Summary
- enforce timeout on Immich and media fetches to avoid hanging requests
- document new FETCH_TIMEOUT env option

## Testing
- `npm test` *(fails: Missing script "test")*
- `PORT=4000 FETCH_TIMEOUT=1000 node server.js >/tmp/run.log 2>&1 &` (server started)
- `curl -I http://localhost:4000/ -m 5`


------
https://chatgpt.com/codex/tasks/task_e_68bacc8a4b58832394a28817e0df89be