### PR TITLE
fix: align compress plugin with Fastify v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 
 # Ignore everything in data folders except .gitkeep files
+node_modules/
 public/data/days/*
 !public/data/days/.gitkeep
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@fastify/cookie": "^9.4.0",
         "@fastify/cors": "^8.4.0",
         "@fastify/static": "^6.12.0",
+        "@fastify/compress": "^7.0.0",
         "dotenv": "^16.3.1",
         "fastify": "^4.29.1"
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@fastify/cookie": "^9.4.0",
     "@fastify/cors": "^8.4.0",
     "@fastify/static": "^6.12.0",
+    "@fastify/compress": "^7.0.0",
     "dotenv": "^16.3.1",
     "fastify": "^4.29.1",
     "exifr": "^7.1.3",

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ import fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
 import cors from '@fastify/cors';
 import fastifyCookie from '@fastify/cookie';
+import fastifyCompress from '@fastify/compress';
 import { anonPlugin } from './anon.js';
 import fs from 'fs/promises';
 import fsSync from 'fs';
@@ -72,6 +73,7 @@ const LOCAL_MEDIA_DIR = process.env.LOCAL_MEDIA_DIR || '';
 const app = fastify({ logger: true });
 app.register(cors, { origin: true });
 app.register(fastifyCookie, { secret: process.env.ANON_COOKIE_SECRET });
+app.register(fastifyCompress);
 app.register(anonPlugin);
 
 // ---- User Identity ----------------------------------------------------------
@@ -872,6 +874,9 @@ app.get('/api/immich/assets/:id/original', async (req, reply) => {
     // Pass through headers we care about
     reply.header('content-type', res.headers.get('content-type') || 'application/octet-stream');
     reply.header('cache-control', res.headers.get('cache-control') || 'public, max-age=604800');
+    const enc = res.headers.get('content-encoding');
+    if (enc) reply.header('content-encoding', enc);
+    reply.header('vary', res.headers.get('vary') || 'accept-encoding');
     return reply.send(res.body);
   } catch (e) {
     reply.code(500).send('immich proxy failed');
@@ -890,6 +895,9 @@ app.get('/api/immich/assets/:id/thumb', async (req, reply) => {
     if (!res.ok) return reply.code(res.status).send(await res.text());
     reply.header('content-type', res.headers.get('content-type') || 'image/jpeg');
     reply.header('cache-control', res.headers.get('cache-control') || 'public, max-age=604800');
+    const enc = res.headers.get('content-encoding');
+    if (enc) reply.header('content-encoding', enc);
+    reply.header('vary', res.headers.get('vary') || 'accept-encoding');
     return reply.send(res.body);
   } catch (e) {
     reply.code(500).send('immich thumb proxy failed');


### PR DESCRIPTION
## Summary
- pin `@fastify/compress` to the v7 line compatible with Fastify v4
- ignore node_modules to avoid accidental commits

## Testing
- `npm test` *(fails: command not found)*
- `node server.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4bbcb14883239087faafb0d8ab60