### PR TITLE
fix: avoid duplicate fastifyCompress declaration

### DIFF
--- a/server.js
+++ b/server.js
@@ -117,12 +117,6 @@ collectAssetHashes(PUBLIC_DIR);
 const app = fastify({ logger: true });
 app.register(cors, { origin: true });
 app.register(fastifyCookie, { secret: process.env.ANON_COOKIE_SECRET });
-let fastifyCompress;
-try {
-  fastifyCompress = (await import('@fastify/compress')).default;
-} catch {
-  app.log.warn('@fastify/compress not installed, skipping compression');
-}
 if (fastifyCompress) app.register(fastifyCompress);
 
 app.register(anonPlugin);


### PR DESCRIPTION
## Summary
- remove redundant `fastifyCompress` import and registration

## Testing
- `node --check server.js`
- `npm test` *(fails: Missing script "test")*
- `node server.js & sleep 1; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_68baedadc4d0832382109e95fe4fa75b