### PR TITLE
Prevent caching of HTML pages

### DIFF
--- a/server.js
+++ b/server.js
@@ -138,6 +138,11 @@ app.register(fastifyStatic, {
   prefix: '/', // so /day.html, /admin/index.html, /js/*
   cacheControl: true,
   maxAge: '1y',
+  setHeaders: (res, filePath) => {
+    if (filePath.endsWith('.html')) {
+      res.setHeader('cache-control', 'no-cache');
+    }
+  },
 });
 
 // expose locally synced media if configured


### PR DESCRIPTION
## Summary
- Disable caching of HTML pages served from `public` so browser refreshes show latest content

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68baf4f6f214832394bd3e46bd72748a