### PR TITLE
Add service worker to cache images

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -247,6 +247,7 @@
     </div>
 
     <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+    <script src="/js/sw-register.js"></script>
     <script type="module" src="/admin/admin.js"></script>
 </body>
 </html>

--- a/public/day.html
+++ b/public/day.html
@@ -28,6 +28,7 @@
   </main>
   <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
   <script src="js/photo-lightbox.js"></script>
+  <script src="js/sw-register.js"></script>
   <script type="module" src="js/day.js"></script>
 
   <div id="overlay-backdrop" class="overlay-backdrop hidden"></div>

--- a/public/debug-auth.html
+++ b/public/debug-auth.html
@@ -122,5 +122,6 @@
             checkStoredTokens();
         };
     </script>
+    <script src="js/sw-register.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -46,8 +46,9 @@
   </section>
 
 
-    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+  <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
   <script src="js/photo-lightbox.js"></script>
+  <script src="js/sw-register.js"></script>
   <script type="module" src="js/index.js"></script>
 </body>
 </html>

--- a/public/js/sw-register.js
+++ b/public/js/sw-register.js
@@ -1,0 +1,7 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(err => {
+      console.error('Service worker registration failed:', err);
+    });
+  });
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,58 @@
+const CACHE_NAME = 'findllamas-v1';
+const STATIC_ASSETS = [
+  '/',
+  '/index.html',
+  '/day.html',
+  '/css/styles.css',
+  '/js/index.js',
+  '/js/day.js',
+  '/js/photo-lightbox.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.map(key => (key !== CACHE_NAME ? caches.delete(key) : null)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (url.origin !== location.origin) return;
+
+  // cache-first for images
+  if (/\.(?:png|jpg|jpeg|gif|webp|avif|svg)$/.test(url.pathname)) {
+    event.respondWith(
+      caches.open(CACHE_NAME).then(cache =>
+        cache.match(request).then(cached => {
+          const fetchPromise = fetch(request).then(response => {
+            cache.put(request, response.clone());
+            return response;
+          });
+          return cached || fetchPromise;
+        })
+      )
+    );
+    return;
+  }
+
+  // network-first for other requests
+  event.respondWith(
+    fetch(request)
+      .then(response => {
+        const copy = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
+        return response;
+      })
+      .catch(() => caches.match(request))
+  );
+});

--- a/public/welcome-old.html
+++ b/public/welcome-old.html
@@ -232,5 +232,6 @@
     });
   });
 </script>
+<script src="js/sw-register.js"></script>
 </body>
 </html>

--- a/public/welcome.html
+++ b/public/welcome.html
@@ -923,5 +923,6 @@
       }
     });
   </script>
+  <script src="js/sw-register.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- cache static assets and images via new service worker
- register service worker on all main pages for automatic updates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bafc6d9b78832389a5ba4cf03e119e