### PR TITLE
chore: adjust service worker caching

### DIFF
--- a/public/js/sw-register.js
+++ b/public/js/sw-register.js
@@ -1,6 +1,8 @@
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch(err => {
+    // updateViaCache:'none' forces the browser to re-fetch sw.js on each load,
+    // avoiding issues where some devices serve a cached, outdated worker.
+    navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' }).catch(err => {
       console.error('Service worker registration failed:', err);
     });
   });

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,15 +1,17 @@
-const CACHE_NAME = 'findllamas-v1';
+// Increment CACHE_NAME to bust old caches on deploys
+const CACHE_NAME = 'findllamas-v2';
+// Only cache static assets that rarely change. HTML files are fetched from
+// the network on each navigation to avoid serving stale pages from cache.
 const STATIC_ASSETS = [
-  '/',
-  '/index.html',
-  '/day.html',
   '/css/styles.css',
   '/js/index.js',
   '/js/day.js',
   '/js/photo-lightbox.js'
 ];
 
+// Activate new versions immediately so clients don't keep old caches
 self.addEventListener('install', event => {
+  self.skipWaiting();
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS))
   );
@@ -17,9 +19,12 @@ self.addEventListener('install', event => {
 
 self.addEventListener('activate', event => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(keys.map(key => (key !== CACHE_NAME ? caches.delete(key) : null)))
-    )
+    caches
+      .keys()
+      .then(keys =>
+        Promise.all(keys.map(key => (key !== CACHE_NAME ? caches.delete(key) : null)))
+      )
+      .then(() => self.clients.claim())
   );
 });
 
@@ -41,6 +46,15 @@ self.addEventListener('fetch', event => {
           return cached || fetchPromise;
         })
       )
+    );
+    return;
+  }
+
+  // Always try the network first for navigation requests so users receive the
+  // latest HTML. Fall back to a cached copy if offline.
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request).catch(() => caches.match('/index.html'))
     );
     return;
   }


### PR DESCRIPTION
## Summary
- avoid stale pages by fetching HTML from network and bumping cache name
- always update service worker script to bypass device caches

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68bb83f4921c8323a6678aef6a3d24c2