### PR TITLE
fix: prevent image reloads on scroll

### DIFF
--- a/public/js/day.js
+++ b/public/js/day.js
@@ -53,6 +53,10 @@ const lazyLoadObserver = new IntersectionObserver((entries) => {
         el.src = el.dataset.src;
         delete el.dataset.src;
       }
+      // Keep loaded media in memory when leaving the viewport
+      if (el.tagName === 'IMG') {
+        el.loading = 'eager';
+      }
       lazyLoadObserver.unobserve(el);
     }
   });
@@ -144,6 +148,10 @@ function renderMediaEl(item, { withControls = false, className = 'media-tile', u
     img.loading = 'lazy';
     img.decoding = 'async';
     img.className = className;
+    // Once loaded, switch to eager so it doesn't unload on scroll
+    img.addEventListener('load', () => {
+      img.loading = 'eager';
+    }, { once: true });
     return img;
   }
 }

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -217,6 +217,11 @@ const lazyLoadObserver = new IntersectionObserver((entries) => {
         delete element.dataset.src;
       }
       
+      // Once media is in view, ensure the browser keeps it loaded
+      if (element.tagName === 'IMG') {
+        element.loading = 'eager';
+      }
+
       lazyLoadObserver.unobserve(element);
     }
   });
@@ -351,6 +356,10 @@ function renderMediaEl(item, { withControls = false, className = '', useThumb = 
     img.alt = item.title || item.caption || '';
     img.loading = 'lazy';
     img.decoding = 'async';
+    // Prevent already-loaded images from being discarded when out of view
+    img.addEventListener('load', () => {
+      img.loading = 'eager';
+    }, { once: true });
 
     if (className) img.className = className;
     element = img;
@@ -2193,6 +2202,10 @@ function renderPhotoGrid(){
     img.src = p.thumb || p.url;
     img.alt = p.caption || '';
     img.loading = 'lazy';
+    // Switch to eager after load so scrolling doesn't trigger re-fetch
+    img.addEventListener('load', () => {
+      img.loading = 'eager';
+    }, { once: true });
     img.addEventListener('click', () => {
       if (window.openPhotoLightbox) {
         window.openPhotoLightbox(photos, idx);


### PR DESCRIPTION
## Summary
- keep lazily-loaded images in memory by switching to eager loading once visible
- avoid photo grid thumbnails re-fetching on scroll

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c7e56588323899a7b47fab8a50c