### PR TITLE
Disable caching for trip data to show new stacks

### DIFF
--- a/server.js
+++ b/server.js
@@ -139,7 +139,8 @@ app.register(fastifyStatic, {
   cacheControl: true,
   maxAge: '1y',
   setHeaders: (res, filePath) => {
-    if (filePath.endsWith('.html')) {
+    const relPath = filePath.replace(/\\/g, '/');
+    if (filePath.endsWith('.html') || relPath.includes('/data/')) {
       res.setHeader('cache-control', 'no-cache');
     }
   },


### PR DESCRIPTION
## Summary
- avoid caching for JSON data in `/public/data` so trip page always reflects new stacks

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc3ecf2170832389ed91fb872a9e19