### PR TITLE
fix: load thumbnails for legacy stacks

### DIFF
--- a/public/js/day.js
+++ b/public/js/day.js
@@ -1,4 +1,4 @@
-import { dataUrl, getApiBase, haversineKm, escapeHtml, formatTime, formatDateTime, groupIntoStacks, formatDate } from "./utils.js";
+import { dataUrl, getApiBase, haversineKm, escapeHtml, formatTime, formatDateTime, groupIntoStacks, formatDate, thumbUrl } from "./utils.js";
 
 const MAPBOX_STYLE = 'mapbox://styles/mapbox/satellite-v9';
 // Use provided Mapbox token by default; replace with your own for production.
@@ -45,7 +45,8 @@ function renderMediaEl(item, { withControls = false, className = 'media-tile', u
       isMobile && item.variants && (item.variants.mobile || item.variants.sd || item.variants.low)
         ? item.variants.mobile || item.variants.sd || item.variants.low
         : item.url;
-    if (item.thumb) v.poster = item.thumb;
+    const t = thumbUrl(item);
+    if (t) v.poster = t;
     v.muted = true;
     v.playsInline = true;
     v.loop = true;
@@ -90,9 +91,10 @@ function renderMediaEl(item, { withControls = false, className = 'media-tile', u
     return v;
   } else {
     const img = document.createElement('img');
-    const thumbSrc = item.thumb || item.url;
+    const t = thumbUrl(item);
+    const thumbSrc = t;
     const srcsetParts = [];
-    if (item.thumb) srcsetParts.push(`${item.thumb} 400w`);
+    if (t) srcsetParts.push(`${t} 400w`);
     if (item.variants?.medium) srcsetParts.push(`${item.variants.medium} 800w`);
     if (item.variants?.large) srcsetParts.push(`${item.variants.large} 1600w`);
     if (item.url) srcsetParts.push(`${item.url} 2400w`);
@@ -376,7 +378,7 @@ function initMap() {
     const bounds = new mapboxgl.LngLatBounds();
     photosWithGPS.forEach(photo => {
       const popup = new mapboxgl.Popup({ offset: 25 }).setHTML(`
-        <img src="${photo.thumb || photo.url}" style="width:100px;height:75px;object-fit:cover;border-radius:4px;" alt="">
+        <img src="${thumbUrl(photo)}" style="width:100px;height:75px;object-fit:cover;border-radius:4px;" alt="">
         <br><strong>${escapeHtml(photo.title || (isVideo(photo) ? 'Video' : 'Photo'))}</strong>
         <br><small>${formatTime(photo.taken_at)}</small>
       `);
@@ -452,7 +454,7 @@ function openFullscreenMapFromRegularMap(sourceMap, containerId) {
       .map(p => ({
         id: p.id,
         url: p.url,
-        thumb: p.thumb || p.url,
+        thumb: thumbUrl(p),
         caption: p.caption || p.title || '',
         title: p.title || '',
         lat: p.lat,
@@ -590,7 +592,7 @@ function openLightbox(index = 0) {
       const photos = dayData.photos.map(photo => ({
         id: photo.id,
         url: photo.url,
-        thumb: photo.thumb,
+        thumb: thumbUrl(photo),
         caption: photo.caption || photo.description || '',
         title: photo.title || '',
         type: isVideo(photo) ? 'video' : 'image'

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,4 +1,4 @@
-import { dataUrl, getApiBase, groupIntoStacks, debounce, urlParam, pushUrlParam, replaceUrlParam, fmtTime, escapeHtml, formatDate } from "./utils.js";
+import { dataUrl, getApiBase, groupIntoStacks, debounce, urlParam, pushUrlParam, replaceUrlParam, fmtTime, escapeHtml, formatDate, thumbUrl } from "./utils.js";
 
 const MAPBOX_STYLE = 'mapbox://styles/mapbox/satellite-v9';
 // Use provided Mapbox token by default; replace with your own for production.
@@ -214,7 +214,7 @@ function renderMediaEl(item, { withControls = false, className = '', useThumb = 
   if (isVideo(item)) {
     const v = document.createElement('video');
     // Always use thumbnail for video poster to improve performance
-    v.poster = item.thumb || '';
+    v.poster = thumbUrl(item);
     v.muted = true;
     v.playsInline = true;
     v.loop = true;
@@ -270,13 +270,14 @@ function renderMediaEl(item, { withControls = false, className = '', useThumb = 
 
     // Determine appropriate source
     const srcsetParts = [];
-    if (item.thumb) srcsetParts.push(`${item.thumb} 400w`);
+    const t = thumbUrl(item);
+    if (t) srcsetParts.push(`${t} 400w`);
     if (item.variants?.medium) srcsetParts.push(`${item.variants.medium} 800w`);
     if (item.url) srcsetParts.push(`${item.url} 1600w`);
     const fullSrcset = srcsetParts.join(', ');
     const sizes = '(max-width: 768px) 100vw, 50vw';
 
-    const thumbSrc = item.thumb || item.url;
+    const thumbSrc = t;
     img.src = thumbSrc;
     if (fullSrcset) {
       img.srcset = fullSrcset;
@@ -555,7 +556,7 @@ function addMarkersAndPath(map){
   }
 
   gpsPhotos.forEach(photo => {
-    const thumb = photo.thumb || photo.url;
+    const thumb = thumbUrl(photo);
     const markerSize = getMarkerSize(map.getZoom());
     const el = document.createElement('div');
     el.className = `photo-marker${photo.stackId === activeStackId ? ' active' : ''}`;
@@ -2086,7 +2087,7 @@ function openLightboxForStack(stack, startIndex=0){
     const photos = stack.photos.map(photo => ({
       id: photo.id,
       url: photo.url,
-      thumb: photo.thumb || photo.url,
+      thumb: thumbUrl(photo),
       caption: photo.caption || '',
       taken_at: photo.taken_at,
       lat: photo.lat,
@@ -2111,7 +2112,7 @@ function renderPhotoGrid(){
   const photos = allPhotos.map(p => ({
     id: p.id,
     url: p.url,
-    thumb: p.thumb || p.url,
+    thumb: thumbUrl(p),
     caption: p.caption || '',
     taken_at: p.taken_at,
     lat: p.lat,
@@ -2122,7 +2123,7 @@ function renderPhotoGrid(){
 
   photos.forEach((p, idx) => {
     const img = document.createElement('img');
-    img.src = p.thumb || p.url;
+    img.src = thumbUrl(p);
     img.alt = p.caption || '';
     img.loading = 'eager';
     img.addEventListener('click', () => {
@@ -2327,7 +2328,7 @@ function openFullscreenMapFromRegularMap(sourceMap, containerId) {
       .map(p => ({
         id: p.id,
         url: p.url,
-        thumb: p.thumb || p.url,
+        thumb: thumbUrl(p),
         caption: p.caption || p.title || '',
         title: p.title || '',
         lat: p.lat,
@@ -2343,7 +2344,7 @@ function openFullscreenMapFromRegularMap(sourceMap, containerId) {
         .map(p => ({
           id: p.id,
           url: p.url,
-          thumb: p.thumb || p.url,
+          thumb: thumbUrl(p),
           caption: p.caption || p.title || '',
           title: p.title || '',
           lat: p.lat,

--- a/public/js/photo-lightbox.js
+++ b/public/js/photo-lightbox.js
@@ -27,6 +27,12 @@ function escapeHtml(s){ return s.replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt
 
 function likeKey(kind, id){ return `liked:${kind}:${id}`; }
 
+// Return a thumbnail URL regardless of whether the media item uses legacy
+// property names. Falls back to the main URL if no thumb is available.
+function thumbUrl(item={}){
+  return item.thumb || item.thumbUrl || item.thumbnailUrl || item.url || '';
+}
+
 function isVideo(item){
   const mt = (item?.mimeType || '').toLowerCase();
   const url = (item?.url || '').toLowerCase();
@@ -518,7 +524,7 @@ window.openPhotoLightbox = (photos, startIndex=0) => {
       img.removeAttribute('srcset');
       vid.style.display = 'block';
       vid.src = p.url;
-      vid.poster = p.thumb || '';
+      vid.poster = thumbUrl(p);
       vid.currentTime = 0;
       const pp = vid.play();
       if (pp && pp.catch) pp.catch(()=>{});
@@ -529,7 +535,7 @@ window.openPhotoLightbox = (photos, startIndex=0) => {
       img.style.display = 'block';
 
       // show thumbnail first
-      const thumbSrc = p.thumb || p.url;
+      const thumbSrc = thumbUrl(p);
       const srcsetParts = [];
       if (p.thumb) srcsetParts.push(`${p.thumb} 400w`);
       if (p.variants?.medium) srcsetParts.push(`${p.variants.medium} 800w`);
@@ -727,7 +733,7 @@ function openFullscreenMapWithPhotos(photos, focusIndex = 0) {
           cursor: pointer;
           background: white;
         ">
-          <img src="${photo.thumb || photo.url}" style="width:100%;height:100%;object-fit:cover;" alt="Photo">
+          <img src="${thumbUrl(photo)}" style="width:100%;height:100%;object-fit:cover;" alt="Photo">
         </div>`;
       const marker = new mapboxgl.Marker(el).setLngLat([photo.lon, photo.lat]).addTo(fullscreenMap);
       el.addEventListener('click', () => {

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -12,6 +12,19 @@ export const replaceUrlParam = (k, v) => {
   const u = new URL(window.location); u.searchParams.set(k, v); history.replaceState(null, "", u);
 };
 
+// --- Media helpers ---
+// Return the best available thumbnail URL for a media item, falling back to
+// known legacy property names before using the full-size URL.
+export function thumbUrl(item = {}) {
+  return (
+    item.thumb ||
+    item.thumbUrl ||
+    item.thumbnailUrl ||
+    item.url ||
+    ''
+  );
+}
+
 // --- API base (single source of truth) ---
 export function getApiBase() {
   try {


### PR DESCRIPTION
## Summary
- ensure thumbnail URLs resolve from legacy fields
- use helper across feeds, day view and lightbox so older stacks show images

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bc5ae056388323ad83bf971ddb2155