### PR TITLE
Ensure stack photos have thumbnail fallback

### DIFF
--- a/public/img/placeholder.svg
+++ b/public/img/placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="75" viewBox="0 0 100 75">
+  <rect width="100" height="75" fill="#ddd"/>
+  <text x="50" y="40" text-anchor="middle" font-size="10" fill="#666">No Image</text>
+</svg>

--- a/public/js/day.js
+++ b/public/js/day.js
@@ -1,4 +1,4 @@
-import { dataUrl, getApiBase, haversineKm, escapeHtml, formatTime, formatDateTime, groupIntoStacks, formatDate, thumbUrl } from "./utils.js";
+import { dataUrl, getApiBase, haversineKm, escapeHtml, formatTime, formatDateTime, groupIntoStacks, formatDate, thumbUrl, FALLBACK_THUMB_URL } from "./utils.js";
 
 const MAPBOX_STYLE = 'mapbox://styles/mapbox/satellite-v9';
 // Use provided Mapbox token by default; replace with your own for production.
@@ -301,6 +301,10 @@ async function loadDayData() {
       throw new Error(`Failed to load day data: ${response.status}`);
     }
     dayData = await response.json();
+    dayData.photos = (dayData.photos || []).map(p => {
+      const t = thumbUrl(p) || FALLBACK_THUMB_URL;
+      return { ...p, url: p.url || t, thumb: p.thumb || t };
+    });
     document.getElementById('day-title').textContent = dayData.title || `Day — ${daySlug}`;
   } catch (error) {
     console.error('Error loading day data:', error);

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,4 +1,4 @@
-import { dataUrl, getApiBase, groupIntoStacks, debounce, urlParam, pushUrlParam, replaceUrlParam, fmtTime, escapeHtml, formatDate, thumbUrl } from "./utils.js";
+import { dataUrl, getApiBase, groupIntoStacks, debounce, urlParam, pushUrlParam, replaceUrlParam, fmtTime, escapeHtml, formatDate, thumbUrl, FALLBACK_THUMB_URL } from "./utils.js";
 
 const MAPBOX_STYLE = 'mapbox://styles/mapbox/satellite-v9';
 // Use provided Mapbox token by default; replace with your own for production.
@@ -436,7 +436,10 @@ async function loadStacks(){
   if (previewSlug){
     const dj = await (await fetch(dataUrl("days", `${previewSlug}.json`))).json();
     stackMetaByDay[previewSlug] = dj.stackMeta || {};
-    (dj.photos||[]).forEach(p=> allPhotos.push({ ...p, dayTitle:dj.title, daySlug:previewSlug, ts:+new Date(p.taken_at) }));
+    (dj.photos||[]).forEach(p=> {
+      const t = thumbUrl(p) || FALLBACK_THUMB_URL;
+      allPhotos.push({ ...p, url: p.url || t, thumb: p.thumb || t, dayTitle:dj.title, daySlug:previewSlug, ts:+new Date(p.taken_at) });
+    });
   } else {
     try {
       const res = await fetch(dataUrl("days", "index.json"));
@@ -446,7 +449,10 @@ async function loadStacks(){
           try {
             const dj = await (await fetch(dataUrl("days", `${d.slug}.json`))).json();
             stackMetaByDay[d.slug] = dj.stackMeta || {};
-            (dj.photos||[]).forEach(p=> allPhotos.push({ ...p, dayTitle:dj.title, daySlug:d.slug, ts:+new Date(p.taken_at) }));
+            (dj.photos||[]).forEach(p=> {
+              const t = thumbUrl(p) || FALLBACK_THUMB_URL;
+              allPhotos.push({ ...p, url: p.url || t, thumb: p.thumb || t, dayTitle:dj.title, daySlug:d.slug, ts:+new Date(p.taken_at) });
+            });
           } catch (e) {
             console.warn(`Failed to load day ${d.slug}:`, e);
           }

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -2,6 +2,9 @@
 export const DATA_ROOT = 'data';
 export const dataUrl = (...parts) => [DATA_ROOT, ...parts].join('/');
 
+// Fallback image for missing thumbnails
+export const FALLBACK_THUMB_URL = '/img/placeholder.svg';
+
 // --- URL helpers ---
 export const qs = (k, s = window.location.search) => new URLSearchParams(s).get(k);
 export const urlParam = qs;
@@ -138,7 +141,16 @@ export function groupIntoStacks(photos, radiusMeters = 500) {
   };
 
   const pushAndRecenter = (stack, photo) => {
-    stack.photos.push(photo);
+    const p = { ...photo };
+    const t = thumbUrl(p);
+    if (t) {
+      if (!p.thumb) p.thumb = t;
+      if (!p.url) p.url = t;
+    } else {
+      p.thumb = FALLBACK_THUMB_URL;
+      if (!p.url) p.url = FALLBACK_THUMB_URL;
+    }
+    stack.photos.push(p);
     const c = centroidOf(stack.photos);
     stack.center = c;
     if (!isFiniteCoord(stack.location.lat) && c) {


### PR DESCRIPTION
## Summary
- add shared fallback thumbnail URL
- guarantee stack photos include thumb and url fields
- sanitize loaded day photos to always include thumbnails

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check public/js/utils.js && node --check public/js/index.js && node --check public/js/day.js`


------
https://chatgpt.com/codex/tasks/task_e_68bceb389400832385f4bbaf2df5dcac