### PR TITLE
feat: lazy load day data

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -15,6 +15,11 @@ let stackMetaByDay = {};
 let activeStackId = null;
 let scrollLocked = false;
 
+// Day loading state for incremental fetching
+const DAYS_PER_LOAD = 3; // number of day files to fetch at a time
+let daysIndex = [];
+let daysLoaded = 0;
+
 // Full-screen map overlay variables
 let mapOverlay, overlayMap, overlayMarker;
 
@@ -428,38 +433,65 @@ function makeDragScrollable(el) {
   el.addEventListener('touchend', onUp);
 }
 
-async function loadStacks(){
+async function loadStacks(count = DAYS_PER_LOAD) {
   const previewSlug = urlParam("preview");
-  allPhotos = [];
-  stackMetaByDay = {};
 
-  if (previewSlug){
-    const dj = await (await fetch(dataUrl("days", `${previewSlug}.json`))).json();
-    stackMetaByDay[previewSlug] = dj.stackMeta || {};
-    (dj.photos||[]).forEach(p=> allPhotos.push({ ...p, dayTitle:dj.title, daySlug:previewSlug, ts:+new Date(p.taken_at) }));
-  } else {
-    try {
-      const res = await fetch(dataUrl("days", "index.json"));
-      const days = res.ok ? await res.json() : [];
-      if (Array.isArray(days) && days.length > 0) {
-  await Promise.all(days.map(async d=>{
-          try {
-            const dj = await (await fetch(dataUrl("days", `${d.slug}.json`))).json();
-            stackMetaByDay[d.slug] = dj.stackMeta || {};
-            (dj.photos||[]).forEach(p=> allPhotos.push({ ...p, dayTitle:dj.title, daySlug:d.slug, ts:+new Date(p.taken_at) }));
-          } catch (e) {
-            console.warn(`Failed to load day ${d.slug}:`, e);
-          }
-        }));
-      } else {
-        console.log("No days found in index.json");
-      }
-    } catch (e) {
-      console.warn("Failed to load days index:", e);
-    }
+  // Reset collections on first load
+  if (daysLoaded === 0) {
+    allPhotos = [];
+    stackMetaByDay = {};
   }
 
-  allPhotos.sort((a,b)=>a.ts-b.ts);
+  if (previewSlug) {
+    // Preview mode loads a single day and skips pagination
+    const dj = await (await fetch(dataUrl("days", `${previewSlug}.json`))).json();
+    stackMetaByDay[previewSlug] = dj.stackMeta || {};
+    (dj.photos || []).forEach((p) =>
+      allPhotos.push({
+        ...p,
+        dayTitle: dj.title,
+        daySlug: previewSlug,
+        ts: +new Date(p.taken_at)
+      })
+    );
+    daysIndex = [{ slug: previewSlug }];
+    daysLoaded = 1;
+  } else {
+    // Load day index once
+    if (daysIndex.length === 0) {
+      try {
+        const res = await fetch(dataUrl("days", "index.json"));
+        daysIndex = res.ok ? await res.json() : [];
+      } catch (e) {
+        console.warn("Failed to load days index:", e);
+      }
+    }
+
+    const slice = daysIndex.slice(daysLoaded, daysLoaded + count);
+    await Promise.all(
+      slice.map(async (d) => {
+        try {
+          const dj = await (
+            await fetch(dataUrl("days", `${d.slug}.json`))
+          ).json();
+          stackMetaByDay[d.slug] = dj.stackMeta || {};
+          (dj.photos || []).forEach((p) =>
+            allPhotos.push({
+              ...p,
+              dayTitle: dj.title,
+              daySlug: d.slug,
+              ts: +new Date(p.taken_at)
+            })
+          );
+        } catch (e) {
+          console.warn(`Failed to load day ${d.slug}:`, e);
+        }
+      })
+    );
+    daysLoaded += slice.length;
+  }
+
+  allPhotos.sort((a, b) => a.ts - b.ts);
 
   // group photos into stacks by proximity (500m radius)
   photoStacks = groupIntoStacks(allPhotos, 500);
@@ -473,7 +505,7 @@ async function loadStacks(){
     const meta = stackMetaByDay[slug]?.[s.id];
     const title = meta?.title?.trim();
     s.title = title || formatDate(s.takenAt);
-    s.caption = meta?.caption || '';
+    s.caption = meta?.caption || "";
     s.photos.forEach((p) => (p.stackId = s.id));
   });
 }
@@ -585,6 +617,15 @@ function updateMarkerSizes(map) {
     const newSize = getMarkerSize(currentZoom);
     m.marker.getElement().style.setProperty('--marker-size', `${newSize}px`);
   });
+}
+
+// Remove existing markers and redraw them using current allPhotos data
+function refreshTopMap() {
+  if (!topMap) return;
+  mapMarkers.forEach(m => m.marker.remove());
+  mapMarkers = [];
+  addMarkersAndPath(topMap);
+  updateMarkerClasses();
 }
 
 
@@ -847,7 +888,24 @@ function renderFeed(){
   // Single DOM operation to append all cards
   host.innerHTML = "";
   host.appendChild(fragment);
-  
+
+  // Append load-more control if more days remain
+  if (daysLoaded < daysIndex.length) {
+    const wrap = document.createElement('div');
+    wrap.className = 'load-more-container';
+    const btn = document.createElement('button');
+    btn.textContent = 'Load more days';
+    btn.addEventListener('click', async () => {
+      btn.disabled = true;
+      await loadStacks();
+      await resolveStackLocations();
+      refreshTopMap();
+      renderFeed();
+    });
+    wrap.appendChild(btn);
+    host.appendChild(wrap);
+  }
+
   localStorage.setItem("stackPhotoCounts", JSON.stringify(newCounts));
 }
 


### PR DESCRIPTION
## Summary
- lazily load day JSON files in batches
- add "Load more days" button to fetch additional batches on demand
- refresh map markers when new days are loaded

## Testing
- `node --check public/js/index.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bcebb44ff883239c4c556b3eb2ec41