### PR TITLE
Fix corrupted index.js preventing photo stacks from rendering

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -422,42 +422,6 @@ async function loadStacks(count = DAYS_PER_LOAD) {
       } catch (e) {
         console.warn("Failed to load days index:", e);
         return;
-412
- 
-  } else {
-413
- 
-    // Load day index once
-414
- 
-    if (daysIndex.length === 0) {
-415
- 
-      try {
-416
- 
-        const res = await fetch(dataUrl("days", "index.json"));
-417
- 
-        daysIndex = res.ok ? await res.json() : [];
-412
- 
-  } else {
-413
- 
-    // Load day index once
-414
- 
-    if (daysIndex.length === 0) {
-415
- 
-      try {
-416
- 
-        const res = await fetch(dataUrl("days", "index.json"));
-417
- 
-        daysIndex = res.ok ? await res.json() : [];
       }
     }
 


### PR DESCRIPTION
## Summary
- remove stray line numbers and duplicated code from the homepage script
- ensure day index loads correctly so photo stacks and images can display

## Testing
- `node --check public/js/index.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd78b8ae388323aef68460cf8b7526