### PR TITLE
Handle missing day data and improve empty state

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -3152,4 +3152,10 @@ body.lightbox-open {
   background: #2563eb;
 }
 
+.no-data {
+  text-align: center;
+  padding: 2rem;
+  color: #666;
+}
+
 


### PR DESCRIPTION
## Summary
- Avoid infinite reload loops by counting attempted day loads
- Gracefully handle missing preview day and missing day files
- Show an empty state message with optional load-more control
- Add basic styling for empty state

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bd7b3661408323885193c6ebd5d77d