### PR TITLE
Generate thumbnails during import

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Since the admin calls your Immich/Dawarich directly, enable CORS on both:
 - The auto-loader groups assets by the day they were taken and writes JSON files like `public/data/days/2025-08-14.json`.
 - Scheduling: there is no built-in scheduler. Run the loader manually or via an external cron job; each run processes one day and will overwrite that day's file on subsequent runs.
 - `ADMIN_TOKEN` (optional): protects admin endpoints. If set, the import button and other admin actions send this token in an `x-admin-token` header.
-- `LOCAL_MEDIA_DIR` (optional): absolute path to a folder of synced media. When set, imported photos point to `/media/` URLs instead of proxying through Immich. Missing thumbnails are generated automatically on request into a `thumbs/` subfolder using [`sharp`](https://sharp.pixelplumbing.com/).
+  - `LOCAL_MEDIA_DIR` (optional): absolute path to a folder of synced media. When set, imported photos point to `/media/` URLs instead of proxying through Immich. Thumbnails are generated during import into a `thumbs/` subfolder using [`sharp`](https://sharp.pixelplumbing.com/).
 
 Minimal `.env` example:
 

--- a/server.js
+++ b/server.js
@@ -757,8 +757,8 @@ async function mapAssetToPhoto(a, serverIndex) {
     : null;
 
   const hasLocal = localOriginal && fsSync.existsSync(localOriginal);
-  let hasThumb = localThumbBase && fsSync.existsSync(`${localThumbBase}-400.jpg`);
-  if (hasLocal && !hasThumb && localThumbBase) {
+  let hasThumb = false;
+  if (hasLocal && localThumbBase) {
     await ensureLocalThumb(localOriginal, localThumbBase);
     hasThumb = fsSync.existsSync(`${localThumbBase}-400.jpg`);
   }
@@ -873,15 +873,11 @@ async function getLocalPhotosForDay({ date }) {
           const localThumbBase = path.join(LOCAL_MEDIA_DIR, 'thumbs', relBase);
           const thumbUrlBase = `/media/thumbs/${relBase}`;
           let thumbUrl = `${thumbUrlBase}-400.jpg`;
+          await ensureLocalThumb(full, localThumbBase);
           try {
             await fs.access(`${localThumbBase}-400.jpg`);
           } catch {
-            await ensureLocalThumb(full, localThumbBase);
-            try {
-              await fs.access(`${localThumbBase}-400.jpg`);
-            } catch {
-              thumbUrl = `/media/${rel}`;
-            }
+            thumbUrl = `/media/${rel}`;
           }
           const variants =
             thumbUrl.startsWith('/media/thumbs/')


### PR DESCRIPTION
## Summary
- Ensure thumbnails are generated for local media during import, creating 400/800/1600px variants.
- Document that thumbnails are now created at import time.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bda40bca548323b80573781b94e333