### PR TITLE
Ensure thumbnails regenerate after media renames

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -23,8 +23,8 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Int
   text-align: center;
   color: #fff;
   padding: 1.5rem 1rem;
-  /* Replace the URL below with your map or hero image if needed */
-  background: #0f172a url('your-map-image.jpg') center / cover no-repeat;
+  /* Solid fallback background (image optional) */
+  background: #0f172a;
 }
 /* Dark gradient + subtle blur overlay for readability */
 .hero::before {


### PR DESCRIPTION
## Summary
- repair missing thumbnails when loading a day's photos and persist updates
- remove broken CSS background reference that caused 404 errors

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be48fd38c88323ab5dc6cd370f14d6