### PR TITLE
feat: allow custom thumbnail directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ Since the admin calls your Immich/Dawarich directly, enable CORS on both:
 - The auto-loader groups assets by the day they were taken and writes JSON files like `public/data/days/2025-08-14.json`.
 - Scheduling: there is no built-in scheduler. Run the loader manually or via an external cron job; each run processes one day and will overwrite that day's file on subsequent runs.
 - `ADMIN_TOKEN` (optional): protects admin endpoints. If set, the import button and other admin actions send this token in an `x-admin-token` header.
-  - `LOCAL_MEDIA_DIR` (optional): absolute path to a folder of synced media. When set, imported photos point to `/media/` URLs instead of proxying through Immich. Thumbnails are generated during import into a `thumbs/` subfolder using [`sharp`](https://sharp.pixelplumbing.com/).
+  - `LOCAL_MEDIA_DIR` (optional): absolute path to a folder of synced media. When set, imported photos point to `/media/` URLs instead of proxying through Immich.
+  - `LOCAL_THUMB_DIR` (optional): directory for generated thumbnails. Defaults to `<LOCAL_MEDIA_DIR>/thumbs` and uses [`sharp`](https://sharp.pixelplumbing.com/).
 
 Minimal `.env` example:
 
@@ -182,6 +183,7 @@ IMMICH_ALBUM_ID=your_album_id
 ADMIN_TOKEN=changeme # required for admin actions like importing
 ANON_COOKIE_SECRET=long_random_string
 LOCAL_MEDIA_DIR=/srv/immich-album
+LOCAL_THUMB_DIR=/srv/immich-album-temp
 
 # Or multiple servers:
 # IMMICH_URLS=https://immich-one.example.com,https://immich-two.example.com
@@ -190,7 +192,7 @@ LOCAL_MEDIA_DIR=/srv/immich-album
 
 Running the loader for `2025-08-14` with the above settings creates `public/data/days/2025-08-14.json` containing only photos from the specified album.
 
-After syncing new files into `LOCAL_MEDIA_DIR`, rerun the admin import so the generated day JSON files reference the local `/media/` paths.
+After syncing new files into `LOCAL_MEDIA_DIR`, rerun the admin import so the generated day JSON files reference the local `/media/` paths and regenerate thumbnails in `LOCAL_THUMB_DIR`.
 
 ## 📝 Daily Workflow
 


### PR DESCRIPTION
## Summary
- allow configuring thumbnail storage via `LOCAL_THUMB_DIR`
- serve and generate thumbs from the custom directory
- document `LOCAL_THUMB_DIR` usage in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check server.js`
- `PORT=0 LOCAL_MEDIA_DIR=/tmp LOCAL_THUMB_DIR=/tmp/thumbs node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68bebe6b34488323b7e7741b87ed8df6