### PR TITLE
feat: add lazy loading and stack caching

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,21 +1,9 @@
 // Increment CACHE_NAME to bust old caches on deploys
-const CACHE_NAME = 'findllamas-v4';
-
-// Only cache static assets that rarely change. HTML files are fetched from
-// the network on each navigation to avoid serving stale pages from cache.
-const STATIC_ASSETS = [
-  '/css/styles.css',
-  '/js/index.js',
-  '/js/day.js',
-  '/js/photo-lightbox.js'
-];
+const CACHE_NAME = 'findllamas-v5';
 
 // Activate new versions immediately so clients don't keep old caches
 self.addEventListener('install', event => {
   self.skipWaiting();
-  event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS))
-  );
 });
 
 self.addEventListener('activate', event => {
@@ -33,18 +21,32 @@ self.addEventListener('fetch', event => {
   const { request } = event;
   const url = new URL(request.url);
 
+  // Cache-first strategy for images
   if (/\.(?:png|jpg|jpeg|gif|webp|avif|svg)$/.test(url.pathname)) {
-    const cacheKey = url.origin + url.pathname;
     event.respondWith(
       caches.open(CACHE_NAME).then(cache =>
-        cache.match(cacheKey).then(cached => {
+        cache.match(request).then(cached => {
           if (cached) return cached;
-          return fetch(request).then(response => {
-            cache.put(cacheKey, response.clone());
-
-            return response;
+          return fetch(request).then(resp => {
+            cache.put(request, resp.clone());
+            return resp;
           });
         })
+      )
+    );
+    return;
+  }
+
+  // Cache stack/day JSON responses but always hit the network first
+  if (url.pathname.startsWith('/data/')) {
+    event.respondWith(
+      caches.open(CACHE_NAME).then(cache =>
+        fetch(request)
+          .then(resp => {
+            cache.put(request, resp.clone());
+            return resp;
+          })
+          .catch(() => cache.match(request))
       )
     );
     return;
@@ -54,22 +56,10 @@ self.addEventListener('fetch', event => {
   if (url.origin !== location.origin) return;
 
   // Always try the network first for navigation requests so users receive the
-  // latest HTML. Fall back to a cached copy if offline.
+  // latest HTML without caching it
   if (request.mode === 'navigate') {
     event.respondWith(
       fetch(request, { cache: 'no-store' }).catch(() => caches.match('/index.html'))
     );
-    return;
   }
-
-  // network-first for other requests
-  event.respondWith(
-    fetch(request)
-      .then(response => {
-        const copy = response.clone();
-        caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
-        return response;
-      })
-      .catch(() => caches.match(request))
-  );
 });


### PR DESCRIPTION
## Summary
- Lazy load photos via `loading="lazy"` and async decoding
- Incrementally fetch day files and append stacks on scroll
- Cache only images and stack JSON via service worker

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bedb29deec832398a0d507fc280701