### PR TITLE
Sort stack feed by most recent first

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -612,11 +612,11 @@ function renderFeed(){
   const seenCounts = JSON.parse(localStorage.getItem("stackPhotoCounts") || "{}");
   const newCounts = {};
   
-  // Sort stacks by newest photo timestamp (oldest stacks first)
+  // Sort stacks by newest photo timestamp (newest stacks first)
   const sortedStacks = [...photoStacks].sort((a, b) => {
     const aNewest = Math.max(...a.photos.map(p => p.ts || 0));
     const bNewest = Math.max(...b.photos.map(p => p.ts || 0));
-    return aNewest - bNewest;
+    return bNewest - aNewest;
   });
   
   // Use document fragment for better performance


### PR DESCRIPTION
## Summary
- Show latest photo stacks at the top of the feed by sorting stacks in descending order by newest photo timestamp

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68beeb027578832383852ef96b9f72f5