### PR TITLE
feat: add default cache-control header

### DIFF
--- a/server.js
+++ b/server.js
@@ -129,6 +129,14 @@ if (fastifyCompress) app.register(fastifyCompress);
 
 app.register(anonPlugin);
 
+// default to no-cache unless a route sets its own policy
+app.addHook('onSend', (req, reply, payload, done) => {
+  if (!reply.getHeader('cache-control')) {
+    reply.header('cache-control', 'no-cache');
+  }
+  done(null, payload);
+});
+
 // ---- User Identity ----------------------------------------------------------
 app.get('/api/user/me', async (req, reply) => {
   console.log('🔍 User ID request:', {


### PR DESCRIPTION
## Summary
- apply a default `Cache-Control: no-cache` header when routes don't specify cache directives

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68beed690e5483238dc53c557690f118